### PR TITLE
Add `neil dep add` entrypoint

### DIFF
--- a/neil
+++ b/neil
@@ -388,7 +388,8 @@ dep
   (let [opts (parse-opts opts)
         opts (with-default-deps-edn opts)]
     (case subcommand
-      "versions" (dep-versions opts))))
+      "versions" (dep-versions opts)
+      "add" (add-dep opts))))
 
 (defn -main []
   (let [[subcommand & args] *command-line-args*]

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -379,7 +379,8 @@ dep
   (let [opts (parse-opts opts)
         opts (with-default-deps-edn opts)]
     (case subcommand
-      "versions" (dep-versions opts))))
+      "versions" (dep-versions opts)
+      "add" (add-dep opts))))
 
 (defn -main []
   (let [[subcommand & args] *command-line-args*]


### PR DESCRIPTION
Exactly the same as `neil dep add` - but fits with `neil dep versions`.