### PR TITLE
Docs for `neil dep add`

### DIFF
--- a/neil
+++ b/neil
@@ -339,16 +339,7 @@ Subcommands:
 
 add
 
-  - dep: adds :lib, a fully qualified symbol, to deps.edn :deps. Example:
-
-    Options:
-
-    :lib - Fully qualified symbol. :lib keyword may be elided when lib name is provided as first option.
-    :version - Optional version. When not provided, picks newest version from Clojars or Maven Central.
-    :sha - When provided, assumes lib refers to Github repo.
-    :latest-sha - When provided, assumes lib refers to Github repo and then picks latest SHA from it.
-    :deps/root - Set :deps/root to given value
-    :as - Use as dependency name in deps.edn
+  - dep: alias for `neil dep add`. Deprecated.
 
   - test: adds cognitect test runner to :test alias.
 
@@ -368,6 +359,17 @@ dep
     Options:
 
     :lib - Fully qualified symbol. :lib keyword may be elided when lib name is provided as first option.
+
+  - add: adds :lib, a fully qualified symbol, to deps.edn :deps.
+
+    Options:
+
+    :lib - Fully qualified symbol. :lib keyword may be elided when lib name is provided as first option.
+    :version - Optional version. When not provided, picks newest version from Clojars or Maven Central.
+    :sha - When provided, assumes lib refers to Github repo.
+    :latest-sha - When provided, assumes lib refers to Github repo and then picks latest SHA from it.
+    :deps/root - Set :deps/root to given value
+    :as - Use as dependency name in deps.edn
 ")))
 
 (defn with-default-deps-edn [opts]

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -355,8 +355,7 @@ dep
     :deps/root - Set :deps/root to given value
     :as - Use as dependency name in deps.edn
 
-  - versions: lists available versions of :lib. Currently suppports Clojars/Maven coordinates, no
-    Git deps.
+  - versions: lists available versions of :lib. Suppports Clojars/Maven coordinates, no Git deps yet.
 
     Options:
 

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -330,16 +330,7 @@ Subcommands:
 
 add
 
-  - dep: adds :lib, a fully qualified symbol, to deps.edn :deps. Example:
-
-    Options:
-
-    :lib - Fully qualified symbol. :lib keyword may be elided when lib name is provided as first option.
-    :version - Optional version. When not provided, picks newest version from Clojars or Maven Central.
-    :sha - When provided, assumes lib refers to Github repo.
-    :latest-sha - When provided, assumes lib refers to Github repo and then picks latest SHA from it.
-    :deps/root - Set :deps/root to given value
-    :as - Use as dependency name in deps.edn
+  - dep: alias for `neil dep add`. Deprecated.
 
   - test: adds cognitect test runner to :test alias.
 
@@ -359,6 +350,17 @@ dep
     Options:
 
     :lib - Fully qualified symbol. :lib keyword may be elided when lib name is provided as first option.
+
+  - add: adds :lib, a fully qualified symbol, to deps.edn :deps.
+
+    Options:
+
+    :lib - Fully qualified symbol. :lib keyword may be elided when lib name is provided as first option.
+    :version - Optional version. When not provided, picks newest version from Clojars or Maven Central.
+    :sha - When provided, assumes lib refers to Github repo.
+    :latest-sha - When provided, assumes lib refers to Github repo and then picks latest SHA from it.
+    :deps/root - Set :deps/root to given value
+    :as - Use as dependency name in deps.edn
 ")))
 
 (defn with-default-deps-edn [opts]

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -344,13 +344,6 @@ add
 
 dep
 
-  - versions: lists available versions of :lib. Currently suppports Clojars/Maven coordinates, no
-    Git deps.
-
-    Options:
-
-    :lib - Fully qualified symbol. :lib keyword may be elided when lib name is provided as first option.
-
   - add: adds :lib, a fully qualified symbol, to deps.edn :deps.
 
     Options:
@@ -361,6 +354,13 @@ dep
     :latest-sha - When provided, assumes lib refers to Github repo and then picks latest SHA from it.
     :deps/root - Set :deps/root to given value
     :as - Use as dependency name in deps.edn
+
+  - versions: lists available versions of :lib. Currently suppports Clojars/Maven coordinates, no
+    Git deps.
+
+    Options:
+
+    :lib - Fully qualified symbol. :lib keyword may be elided when lib name is provided as first option.
 ")))
 
 (defn with-default-deps-edn [opts]


### PR DESCRIPTION
Which I forgot in https://github.com/babashka/neil/pull/19.

We haven't discussed whether `neil add dep` should be deprecated. Should it? Regardless, I'd prefer to avoid having to duplicate the command documentation.