### PR TITLE
Quote dep search string

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ NOTE: invoking a clojure tool requires you to quote strings:
 clj -Tneil add-dep :lib org.clojure/tools.cli :version '"1.0.206"'
 ```
 
-## Roapmap
+## Roadmap
 
 - Add `bb.edn`-related features for invoking `test` and `build` tasks
 - Consider `neil test :only foo.bar` which invokes `clojure -M:test -n foo.bar`

--- a/README.md
+++ b/README.md
@@ -161,6 +161,29 @@ To change the alias you can provide an option like:
 $ neil add kaocha :alias kaocha2
 ```
 
+### dep search
+
+Search Clojars for a string in any attribute of an artifact:
+
+```
+$ neil dep search "babashka.nrepl"
+:lib babashka/babashka.nrepl :version 0.0.6
+```
+
+Note that Clojars stores the namespace and name of a library as separate attributes, so searching for a ns-qualified library will not necessarily return any matches:
+
+```
+$ neil dep search "babashka/babashka.nrepl"
+Unable to find babashka/babashka.nrepl on Clojars.
+```
+
+But a search string can be matched in a library's description:
+
+```
+$ neil dep search "test framework"
+```
+will return libraries with 'test framework' in their description.
+
 ## Tools usage
 
 Instead of a babashka CLI script, you can install and invoke `neil` as a [clojure tool](https://clojure.org/reference/deps_and_cli#tool_install):

--- a/neil
+++ b/neil
@@ -17,7 +17,11 @@
          '[clojure.edn :as edn]
          '[clojure.string :as str])
 
+(import java.net.URLEncoder)
+
 (def windows? (str/includes? (System/getProperty "os.name") "Windows"))
+
+(defn url-encode [s] (URLEncoder/encode s "UTF-8"))
 
 (def curl-opts
   {:throw false
@@ -320,7 +324,7 @@
 
 (defn dep-search [opts]
   (let [search-term (first (:cmds opts))
-        url (str "https://clojars.org/search?format=json&q=" search-term)
+        url (str "https://clojars.org/search?format=json&q=\"" (url-encode search-term) "\"")
         {search-results :results
          results-count :count} (curl-get-json url)]
     (when (zero? results-count)

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -8,7 +8,11 @@
          '[clojure.edn :as edn]
          '[clojure.string :as str])
 
+(import java.net.URLEncoder)
+
 (def windows? (str/includes? (System/getProperty "os.name") "Windows"))
+
+(defn url-encode [s] (URLEncoder/encode s "UTF-8"))
 
 (def curl-opts
   {:throw false
@@ -311,7 +315,7 @@
 
 (defn dep-search [opts]
   (let [search-term (first (:cmds opts))
-        url (str "https://clojars.org/search?format=json&q=" search-term)
+        url (str "https://clojars.org/search?format=json&q=\"" (url-encode search-term) "\"")
         {search-results :results
          results-count :count} (curl-get-json url)]
     (when (zero? results-count)

--- a/tests.clj
+++ b/tests.clj
@@ -43,7 +43,10 @@
   (is (some #(re-matches  #":lib hiccups/hiccups :version \d+(\.\d+)+" % )
             (run-dep-subcommand "search" "hiccups")))
   (is (some #(re-matches  #":lib macchiato/hiccups :version \d+(\.\d+)+" % )
-            (run-dep-subcommand "search" "hiccups"))))
+            (run-dep-subcommand "search" "hiccups")))
+  ; tests for no exception thrown
+  (is (any? (run-dep-subcommand "search" "org.clojure/tools.cli")))
+  (is (any? (run-dep-subcommand "search" "babashka nrepl"))))
 
 (when (= *file* (System/getProperty "babashka.file"))
   (t/run-tests *ns*))

--- a/tests.clj
+++ b/tests.clj
@@ -44,9 +44,11 @@
             (run-dep-subcommand "search" "hiccups")))
   (is (some #(re-matches  #":lib macchiato/hiccups :version \d+(\.\d+)+" % )
             (run-dep-subcommand "search" "hiccups")))
-  ; tests for no exception thrown
+  ; tests for no NPEs/json parsing exceptions
   (is (any? (run-dep-subcommand "search" "org.clojure/tools.cli")))
-  (is (any? (run-dep-subcommand "search" "babashka nrepl"))))
+  (is (any? (run-dep-subcommand "search" "babashka nrepl")))
+  (is (thrown-with-msg? Exception #"Unable to find"
+        (run-dep-subcommand "search" "%22searchTermThatIsn'tFound"))))
 
 (when (= *file* (System/getProperty "babashka.file"))
   (t/run-tests *ns*))


### PR DESCRIPTION
fixes #27 

- quote and URL-encode search string to avoid malformed URLs/Clojars lucene syntax issues
- add `dep search` section to readme with examples