### PR TITLE
add license command

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,21 @@ dep
     Options:
 
     :lib - Fully qualified symbol. :lib keyword may be elided when lib name is provided as first option.
+    
+license
+
+  - list: lists commonly-used licenses available to be added to project. Takes an optional search string
+          to filter results.
+          
+  - search: alias for `list`
+  
+  - add: writes license text to a file
+  
+    Options:
+    
+    :license - The key of the license to use (e.g. epl-1.0, mit, unlicense). :license keyword may be
+               elided when license key is provided as first argument.
+    :file - The file to write. Defaults to 'LICENSE'.
 ```
 
 ### add dep
@@ -161,6 +176,70 @@ To change the alias you can provide an option like:
 $ neil add kaocha :alias kaocha2
 ```
 
+### dep search
+
+Search Clojars for a string in any attribute of an artifact:
+
+```
+$ neil dep search "babashka.nrepl"
+:lib babashka/babashka.nrepl :version 0.0.6
+```
+
+Note that Clojars stores the namespace and name of a library as separate attributes, so searching for a ns-qualified library will not necessarily return any matches:
+
+```
+$ neil dep search "babashka/babashka.nrepl"
+Unable to find babashka/babashka.nrepl on Clojars.
+```
+
+But a search string can be matched in a library's description:
+
+```
+$ neil dep search "test framework"
+```
+will return libraries with 'test framework' in their description.
+
+### license list
+
+List/search for licenses that can be added to a project with `neil`. This functionality uses Github's license API, 
+which is also used by [choosealicense.com](https://choosealicense.com/). With no search term, a list of 
+commonly-used licenses is returned:
+
+```
+$ neil license list
+:key agpl-3.0 :name GNU Affero General Public License v3.0
+:key apache-2.0 :name Apache License 2.0
+...
+```
+
+A search term can be added to filter the commonly-used list with a case-insensitive search against the license name:
+
+```
+$ neil license list "lesser general"
+:key lgpl-2.1 :name GNU Lesser General Public License v2.1
+```
+
+The full collection of available licenses can be found in the [license API repo](https://github.com/github/choosealicense.com/tree/gh-pages/_licenses).
+
+`license search` is an alias for `license list`.
+
+### license add
+
+Retrieve license text from Github's license API and write it to a file. See the `license list` help for details on available licenses.
+
+```
+$ neil license add :license mit :file myproj/license.txt
+```
+
+Will write the MIT license to the file myproject/license.txt. The `:license` keyword can be left out if the license key is the first argument,
+and `:file` defaults to LICENSE, so a minimal usage:
+
+```
+$ neil license add epl-1.0
+```
+
+Will create a LICENSE file in the current directory with the EPL 1.0 text.
+
 ## Tools usage
 
 Instead of a babashka CLI script, you can install and invoke `neil` as a [clojure tool](https://clojure.org/reference/deps_and_cli#tool_install):
@@ -181,7 +260,7 @@ NOTE: invoking a clojure tool requires you to quote strings:
 clj -Tneil add-dep :lib org.clojure/tools.cli :version '"1.0.206"'
 ```
 
-## Roapmap
+## Roadmap
 
 - Add `bb.edn`-related features for invoking `test` and `build` tasks
 - Consider `neil test :only foo.bar` which invokes `clojure -M:test -n foo.bar`

--- a/README.template.md
+++ b/README.template.md
@@ -119,6 +119,29 @@ To change the alias you can provide an option like:
 $ neil add kaocha :alias kaocha2
 ```
 
+### dep search
+
+Search Clojars for a string in any attribute of an artifact:
+
+```
+$ neil dep search "babashka.nrepl"
+:lib babashka/babashka.nrepl :version 0.0.6
+```
+
+Note that Clojars stores the namespace and name of a library as separate attributes, so searching for a ns-qualified library will not necessarily return any matches:
+
+```
+$ neil dep search "babashka/babashka.nrepl"
+Unable to find babashka/babashka.nrepl on Clojars.
+```
+
+But a search string can be matched in a library's description:
+
+```
+$ neil dep search "test framework"
+```
+will return libraries with 'test framework' in their description.
+
 ## Tools usage
 
 Instead of a babashka CLI script, you can install and invoke `neil` as a [clojure tool](https://clojure.org/reference/deps_and_cli#tool_install):
@@ -139,7 +162,7 @@ NOTE: invoking a clojure tool requires you to quote strings:
 clj -Tneil add-dep :lib org.clojure/tools.cli :version '"1.0.206"'
 ```
 
-## Roapmap
+## Roadmap
 
 - Add `bb.edn`-related features for invoking `test` and `build` tasks
 - Consider `neil test :only foo.bar` which invokes `clojure -M:test -n foo.bar`

--- a/README.template.md
+++ b/README.template.md
@@ -166,6 +166,23 @@ The full collection of available licenses can be found in the [license API repo]
 
 `license search` is an alias for `license list`.
 
+### license add
+
+Retrieve license text from Github's license API and write it to a file. See the `license list` help for details on available licenses.
+
+```
+$ neil license add :license mit :file myproj/license.txt
+```
+
+Will write the MIT license to the file myproject/license.txt. The `:license` keyword can be left out if the license key is the first argument,
+and `:file` defaults to LICENSE, so a minimal usage:
+
+```
+$ neil license add epl-1.0
+```
+
+Will create a LICENSE file in the current directory with the EPL 1.0 text.
+
 ## Tools usage
 
 Instead of a babashka CLI script, you can install and invoke `neil` as a [clojure tool](https://clojure.org/reference/deps_and_cli#tool_install):

--- a/README.template.md
+++ b/README.template.md
@@ -142,6 +142,30 @@ $ neil dep search "test framework"
 ```
 will return libraries with 'test framework' in their description.
 
+### license list
+
+List/search for licenses that can be added to a project with `neil`. This functionality uses Github's license API, 
+which is also used by [choosealicense.com](https://choosealicense.com/). With no search term, a list of 
+commonly-used licenses is returned:
+
+```
+$ neil license list
+:key agpl-3.0 :name GNU Affero General Public License v3.0
+:key apache-2.0 :name Apache License 2.0
+...
+```
+
+A search term can be added to filter the commonly-used list with a case-insensitive search against the license name:
+
+```
+$ neil license list "lesser general"
+:key lgpl-2.1 :name GNU Lesser General Public License v2.1
+```
+
+The full collection of available licenses can be found in the [license API repo](https://github.com/github/choosealicense.com/tree/gh-pages/_licenses).
+
+`license search` is an alias for `license list`.
+
 ## Tools usage
 
 Instead of a babashka CLI script, you can install and invoke `neil` as a [clojure tool](https://clojure.org/reference/deps_and_cli#tool_install):

--- a/neil
+++ b/neil
@@ -382,6 +382,22 @@ dep
     Options:
 
     :lib - Fully qualified symbol. :lib keyword may be elided when lib name is provided as first option.
+    
+license
+
+  - list: lists commonly-used licenses available to be added to project. Takes an optional search string
+          to filter results.
+          
+  - search: alias for `list`
+  
+  - add: writes license text to a file
+  
+    Options:
+    
+    :license - The key of the license to use (e.g. epl-1.0, mit, unlicense). :license keyword may be
+               elided when license key is provided as first argument.
+    :file - The file to write. Defaults to 'LICENSE'.
+  
 ")))
 
 (defn with-default-deps-edn [opts]
@@ -410,6 +426,28 @@ dep
       (doseq [result search-results]
         (println :key (:key result) :name (:name result))))))
 
+(defn license-to-file [opts]
+  (let [license-key (or (:license opts) (first (:cmds opts)))
+        output-file (or (:file opts) "LICENSE")
+        {:keys [message name body]} (some->> license-key url-encode
+                                      (str licenses-api-url "/")
+                                      curl-get-json)]
+    (cond
+      (not license-key) (throw (ex-info "No license key provided." {}))
+      (= message "Not Found") 
+        (throw (ex-info (format "License '%s' not found." license-key) {:license license-key}))
+      (not body)
+        (throw (ex-info (format "License '%s' has no body text." (or name license-key)) 
+                 {:license license-key}))
+      :else (spit output-file body))))
+
+(defn add-license [opts]
+  (try
+    (license-to-file opts)
+    (catch Exception e
+      (binding [*out* *err*]
+        (println (ex-message e))
+        (System/exit 1)))))
 
 
 (defn add [[subcommand & opts]]
@@ -432,7 +470,8 @@ dep
 (defn license [[subcommand & opts]]
   (let [opts (parse-opts opts)]
     (case subcommand
-      ("list" "search") (license-search opts))))
+      ("list" "search") (license-search opts)
+      "add" (add-license opts))))
 
 (defn -main []
   (let [[subcommand & args] *command-line-args*]

--- a/neil
+++ b/neil
@@ -389,6 +389,29 @@ dep
     opts
     (assoc opts :deps-file "deps.edn")))
 
+;; licenses
+(def licenses-api-url "https://api.github.com/licenses")
+
+(defn license-search [opts]
+  (let [search-term (first (:cmds opts))
+        license-vec (->> (str licenses-api-url "?per_page=50")
+                      curl-get-json
+                      (map #(select-keys % [:key :name])))
+        search-results (if search-term
+                         (filter #(str/includes? 
+                                    (str/lower-case (:name %))
+                                    (str/lower-case search-term)) 
+                           license-vec)
+                         license-vec)]
+    (if (empty? search-results)
+      (binding [*out* *err*]
+        (println "No licenses found")
+        (System/exit 1))
+      (doseq [result search-results]
+        (println :key (:key result) :name (:name result))))))
+
+
+
 (defn add [[subcommand & opts]]
   (let [opts (parse-opts opts)
         opts (with-default-deps-edn opts)]
@@ -406,11 +429,17 @@ dep
       "add" (add-dep opts)
       "search" (dep-search opts))))
 
+(defn license [[subcommand & opts]]
+  (let [opts (parse-opts opts)]
+    (case subcommand
+      ("list" "search") (license-search opts))))
+
 (defn -main []
   (let [[subcommand & args] *command-line-args*]
     (case subcommand
       "add" (add args)
       "dep" (dep args)
+      "license" (license args)
       ("help" "--help") (print-help)
       (print-help))))
 

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -379,7 +379,15 @@ license
   - list: lists commonly-used licenses available to be added to project. Takes an optional search string
           to filter results.
           
-  - search: alias for `list`  
+  - search: alias for `list`
+  
+  - add: writes license text to a file
+  
+    Options:
+    
+    :license - The key of the license to use (e.g. epl-1.0, mit, unlicense). :license keyword may be
+               elided when license key is provided as first argument.
+    :file - The file to write. Defaults to 'LICENSE'.
   
 ")))
 
@@ -409,6 +417,28 @@ license
       (doseq [result search-results]
         (println :key (:key result) :name (:name result))))))
 
+(defn license-to-file [opts]
+  (let [license-key (or (:license opts) (first (:cmds opts)))
+        output-file (or (:file opts) "LICENSE")
+        {:keys [message name body]} (some->> license-key url-encode
+                                      (str licenses-api-url "/")
+                                      curl-get-json)]
+    (cond
+      (not license-key) (throw (ex-info "No license key provided." {}))
+      (= message "Not Found") 
+        (throw (ex-info (format "License '%s' not found." license-key) {:license license-key}))
+      (not body)
+        (throw (ex-info (format "License '%s' has no body text." (or name license-key)) 
+                 {:license license-key}))
+      :else (spit output-file body))))
+
+(defn add-license [opts]
+  (try
+    (license-to-file opts)
+    (catch Exception e
+      (binding [*out* *err*]
+        (println (ex-message e))
+        (System/exit 1)))))
 
 
 (defn add [[subcommand & opts]]
@@ -431,7 +461,8 @@ license
 (defn license [[subcommand & opts]]
   (let [opts (parse-opts opts)]
     (case subcommand
-      ("list" "search") (license-search opts))))
+      ("list" "search") (license-search opts)
+      "add" (add-license opts))))
 
 (defn -main []
   (let [[subcommand & args] *command-line-args*]

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -373,6 +373,14 @@ dep
     Options:
 
     :lib - Fully qualified symbol. :lib keyword may be elided when lib name is provided as first option.
+    
+license
+
+  - list: lists commonly-used licenses available to be added to project. Takes an optional search string
+          to filter results.
+          
+  - search: alias for `list`  
+  
 ")))
 
 (defn with-default-deps-edn [opts]

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -380,6 +380,29 @@ dep
     opts
     (assoc opts :deps-file "deps.edn")))
 
+;; licenses
+(def licenses-api-url "https://api.github.com/licenses")
+
+(defn license-search [opts]
+  (let [search-term (first (:cmds opts))
+        license-vec (->> (str licenses-api-url "?per_page=50")
+                      curl-get-json
+                      (map #(select-keys % [:key :name])))
+        search-results (if search-term
+                         (filter #(str/includes? 
+                                    (str/lower-case (:name %))
+                                    (str/lower-case search-term)) 
+                           license-vec)
+                         license-vec)]
+    (if (empty? search-results)
+      (binding [*out* *err*]
+        (println "No licenses found")
+        (System/exit 1))
+      (doseq [result search-results]
+        (println :key (:key result) :name (:name result))))))
+
+
+
 (defn add [[subcommand & opts]]
   (let [opts (parse-opts opts)
         opts (with-default-deps-edn opts)]
@@ -397,11 +420,17 @@ dep
       "add" (add-dep opts)
       "search" (dep-search opts))))
 
+(defn license [[subcommand & opts]]
+  (let [opts (parse-opts opts)]
+    (case subcommand
+      ("list" "search") (license-search opts))))
+
 (defn -main []
   (let [[subcommand & args] *command-line-args*]
     (case subcommand
       "add" (add args)
       "dep" (dep args)
+      "license" (license args)
       ("help" "--help") (print-help)
       (print-help))))
 

--- a/tests.clj
+++ b/tests.clj
@@ -1,13 +1,13 @@
 (ns tests
   (:require
-    [babashka.fs :as fs]
-    [babashka.process :refer [check process tokenize]]
-    [babashka.tasks :as tasks]
-    [clojure.edn :as edn]
-    [clojure.string :as str]
-    [clojure.test :as t :refer [deftest is testing]]
-    [clojure.string :as str]
-    [clojure.string :as str]))
+   [babashka.fs :as fs]
+   [babashka.process :refer [check process tokenize]]
+   [babashka.tasks :as tasks]
+   [clojure.edn :as edn]
+   [clojure.string :as str]
+   [clojure.test :as t :refer [deftest is testing]]
+   [clojure.string :as str]
+   [clojure.string :as str]))
 
 (defn test-file [name]
   (doto (fs/file (fs/temp-dir) "neil" name)

--- a/tests.clj
+++ b/tests.clj
@@ -1,16 +1,20 @@
 (ns tests
   (:require
-   [babashka.fs :as fs]
-   [babashka.process :refer [check process tokenize]]
-   [babashka.tasks :as tasks]
-   [clojure.edn :as edn]
-   [clojure.string :as str]
-   [clojure.test :as t :refer [deftest is]]))
+    [babashka.fs :as fs]
+    [babashka.process :refer [check process tokenize]]
+    [babashka.tasks :as tasks]
+    [clojure.edn :as edn]
+    [clojure.string :as str]
+    [clojure.test :as t :refer [deftest is testing]]
+    [clojure.string :as str]))
+
+(defn test-file [name]
+  (doto (fs/file (fs/temp-dir) "neil" name)
+    (-> fs/parent (fs/create-dirs))
+    (fs/delete-on-exit)))
 
 (defn neil [arg & args]
-  (let [tmp-file (doto (fs/file (fs/temp-dir) "neil"  "deps.edn")
-                   (-> fs/parent (fs/create-dirs))
-                   (fs/delete-on-exit))]
+  (let [tmp-file (test-file "deps.edn")]
     (apply tasks/shell "./neil"
            (concat (tokenize arg) [:deps-file tmp-file] args))
     (let [s (slurp tmp-file)]
@@ -49,6 +53,20 @@
   (is (any? (run-dep-subcommand "search" "babashka nrepl")))
   (is (thrown-with-msg? Exception #"Unable to find"
         (run-dep-subcommand "search" "%22searchTermThatIsn'tFound"))))
+
+(defn run-license [filename subcommand & args]
+  (let [lic-file (when filename (test-file filename))]
+    (-> (process (concat ["./neil" "license" subcommand] 
+                   args (when lic-file [:file lic-file])) {:out :string})
+      check :out str/split-lines)))
+
+(deftest license-list-test
+  (testing "list/search with no args returns lines with key and name"
+    (is (every? #(re-find #"^:key.*:name" %) (run-license nil "list"))))
+  (testing "search with matching term prints results"
+    (is (not-empty (run-license nil "search" "license"))))
+  (testing "search for non-existing license prints error"
+    (is (thrown-with-msg? Exception #"No licenses" (run-license nil "search" "nonExistentLicense")))))
 
 (when (= *file* (System/getProperty "babashka.file"))
   (t/run-tests *ns*))

--- a/tests.clj
+++ b/tests.clj
@@ -5,9 +5,7 @@
    [babashka.tasks :as tasks]
    [clojure.edn :as edn]
    [clojure.string :as str]
-   [clojure.test :as t :refer [deftest is testing]]
-   [clojure.string :as str]
-   [clojure.string :as str]))
+   [clojure.test :as t :refer [deftest is testing]]))
 
 (defn test-file [name]
   (doto (fs/file (fs/temp-dir) "neil" name)


### PR DESCRIPTION
closes #14 

**Change summary**
- add license command with subcommands list, search, and add (and some corresponding tests)

**Notes**
- I didn't notice the readme template before, so the readme changes from `dep search` are re-applied here in the template
- I partially separated the license retrieval and the UX in anticipation of incorporating license retrieval into `neil new`
- As a follow-up, I'd like to go back and refactor some commonality out (e.g. error printing) - for now, I wanted to keep the changes mostly isolated