### PR TITLE
make license output readable

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,26 @@ NOTE: invoking a clojure tool requires you to quote strings:
 clj -Tneil add-dep :lib org.clojure/tools.cli :version '"1.0.206"'
 ```
 
+## Emacs Integration
+
+[neil.el](https://github.com/babashka/neil/blob/main/neil.el) is a companion Emacs package.
+
+Load it using your preferred Emacs package manager, e.g., for Doom Emacs:
+
+```emacs-lisp
+;; packages.el
+
+(package! neil :recipe (:host github :repo "babashka/neil" :files ("*.el")))
+
+;; config.el
+
+(use-package! neil
+  :config 
+  (setq neil-prompt-for-version-p nil
+        neil-inject-dep-to-project-p t))
+
+```
+
 ## Roadmap
 
 - Add `bb.edn`-related features for invoking `test` and `build` tasks

--- a/README.md
+++ b/README.md
@@ -207,8 +207,8 @@ commonly-used licenses is returned:
 
 ```
 $ neil license list
-:key agpl-3.0 :name GNU Affero General Public License v3.0
-:key apache-2.0 :name Apache License 2.0
+:license agpl-3.0 :name GNU Affero General Public License v3.0
+:license apache-2.0 :name Apache License 2.0
 ...
 ```
 
@@ -216,7 +216,7 @@ A search term can be added to filter the commonly-used list with a case-insensit
 
 ```
 $ neil license list "lesser general"
-:key lgpl-2.1 :name GNU Lesser General Public License v2.1
+:license lgpl-2.1 :name GNU Lesser General Public License v2.1
 ```
 
 The full collection of available licenses can be found in the [license API repo](https://github.com/github/choosealicense.com/tree/gh-pages/_licenses).
@@ -258,26 +258,6 @@ NOTE: invoking a clojure tool requires you to quote strings:
 
 ``` clojure
 clj -Tneil add-dep :lib org.clojure/tools.cli :version '"1.0.206"'
-```
-
-## Emacs Integration 
-
-[neil.el](https://github.com/babashka/neil/blob/main/neil.el) is a companion Emacs package. 
-
-Load it using your preferred Emacs package manager, e.g., for Doom Emacs:
-
-```emacs-lisp
-;; packages.el
-
-(package! neil :recipe (:host github :repo "babashka/neil" :files ("*.el")))
-
-;; config.el
-
-(use-package! neil
-  :config 
-  (setq neil-prompt-for-version-p nil
-        neil-inject-dep-to-project-p t))
-
 ```
 
 ## Roadmap

--- a/README.md
+++ b/README.md
@@ -260,9 +260,9 @@ NOTE: invoking a clojure tool requires you to quote strings:
 clj -Tneil add-dep :lib org.clojure/tools.cli :version '"1.0.206"'
 ```
 
-## Emacs Integration
+## Emacs Integration 
 
-[neil.el](https://github.com/babashka/neil/blob/main/neil.el) is a companion Emacs package.
+[neil.el](https://github.com/babashka/neil/blob/main/neil.el) is a companion Emacs package. 
 
 Load it using your preferred Emacs package manager, e.g., for Doom Emacs:
 

--- a/README.template.md
+++ b/README.template.md
@@ -203,9 +203,9 @@ NOTE: invoking a clojure tool requires you to quote strings:
 clj -Tneil add-dep :lib org.clojure/tools.cli :version '"1.0.206"'
 ```
 
-## Emacs Integration
+## Emacs Integration 
 
-[neil.el](https://github.com/babashka/neil/blob/main/neil.el) is a companion Emacs package.
+[neil.el](https://github.com/babashka/neil/blob/main/neil.el) is a companion Emacs package. 
 
 Load it using your preferred Emacs package manager, e.g., for Doom Emacs:
 

--- a/README.template.md
+++ b/README.template.md
@@ -150,8 +150,8 @@ commonly-used licenses is returned:
 
 ```
 $ neil license list
-:key agpl-3.0 :name GNU Affero General Public License v3.0
-:key apache-2.0 :name Apache License 2.0
+:license agpl-3.0 :name GNU Affero General Public License v3.0
+:license apache-2.0 :name Apache License 2.0
 ...
 ```
 
@@ -159,7 +159,7 @@ A search term can be added to filter the commonly-used list with a case-insensit
 
 ```
 $ neil license list "lesser general"
-:key lgpl-2.1 :name GNU Lesser General Public License v2.1
+:license lgpl-2.1 :name GNU Lesser General Public License v2.1
 ```
 
 The full collection of available licenses can be found in the [license API repo](https://github.com/github/choosealicense.com/tree/gh-pages/_licenses).

--- a/README.template.md
+++ b/README.template.md
@@ -203,6 +203,26 @@ NOTE: invoking a clojure tool requires you to quote strings:
 clj -Tneil add-dep :lib org.clojure/tools.cli :version '"1.0.206"'
 ```
 
+## Emacs Integration
+
+[neil.el](https://github.com/babashka/neil/blob/main/neil.el) is a companion Emacs package.
+
+Load it using your preferred Emacs package manager, e.g., for Doom Emacs:
+
+```emacs-lisp
+;; packages.el
+
+(package! neil :recipe (:host github :repo "babashka/neil" :files ("*.el")))
+
+;; config.el
+
+(use-package! neil
+  :config 
+  (setq neil-prompt-for-version-p nil
+        neil-inject-dep-to-project-p t))
+
+```
+
 ## Roadmap
 
 - Add `bb.edn`-related features for invoking `test` and `build` tasks

--- a/neil
+++ b/neil
@@ -424,7 +424,7 @@ license
         (println "No licenses found")
         (System/exit 1))
       (doseq [result search-results]
-        (println :key (:key result) :name (:name result))))))
+        (println :license (:key result) :name (pr-str (:name result)))))))
 
 (defn license-to-file [opts]
   (let [license-key (or (:license opts) (first (:cmds opts)))

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -415,7 +415,7 @@ license
         (println "No licenses found")
         (System/exit 1))
       (doseq [result search-results]
-        (println :key (:key result) :name (:name result))))))
+        (println :license (:key result) :name (pr-str (:name result)))))))
 
 (defn license-to-file [opts]
   (let [license-key (or (:license opts) (first (:cmds opts)))

--- a/tests.clj
+++ b/tests.clj
@@ -61,7 +61,7 @@
 
 (deftest license-list-test
   (testing "list/search with no args returns lines with key and name"
-    (is (every? #(re-find #"^:key.*:name" %) (run-license nil "list"))))
+    (is (every? #(re-find #"^:license.*:name" %) (run-license nil "list"))))
   (testing "search with matching term prints results"
     (is (not-empty (run-license nil "search" "license"))))
   (testing "search for non-existing license prints error"


### PR DESCRIPTION
Change `:key` to `:license` in license list output and pr-str the license name so it's readable. This allows for piping list output back into license add.

Also added emacs readme text to template.