### PR TITLE
Entrypoint for `neil --version`

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -18,6 +18,13 @@
                                    version (str/join "." [major minor (inc (Integer/parseInt patch))])]
                                (spit "version.txt" version)
                                version)}
+         sync-version (let [version (-> (slurp "version.txt") str/trim)
+                            oldsource (slurp "src/babashka/neil.clj")
+                            newsource (str/replace oldsource
+                                                   ;; Regex literals like #"\(def version \"[0-9\.]+\"\)" are not supported in bb.edn
+                                                   (re-pattern "\\(def version \\\"[0-9\\.]+\\\"\\)")
+                                                   (str "(def version \"" version "\")"))]
+                        (spit "src/babashka/neil.clj" newsource))
          tests {:depends [gen-script]
                 :task (do (load-file "tests.clj")
                           (let [{:keys [error fail]} (clojure.test/run-tests 'tests)]
@@ -31,6 +38,7 @@
                   (do
                     (run 'tests)
                     (run 'bump-version)
+                    (run 'sync-version)
                     (run 'update-readme)
                     (shell "git add .")
                     (let [version (slurp "version.txt")]

--- a/neil
+++ b/neil
@@ -482,6 +482,7 @@ license
       "add" (add args)
       "dep" (dep args)
       "license" (license args)
+      ("version" "--version") (println "neil" version)
       ("help" "--help") (print-help)
       (print-help))))
 

--- a/neil
+++ b/neil
@@ -19,6 +19,8 @@
 
 (import java.net.URLEncoder)
 
+(def version "0.0.29")
+
 (def windows? (str/includes? (System/getProperty "os.name") "Windows"))
 
 (defn url-encode [s] (URLEncoder/encode s "UTF-8"))

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -473,6 +473,7 @@ license
       "add" (add args)
       "dep" (dep args)
       "license" (license args)
+      ("version" "--version") (println "neil" version)
       ("help" "--help") (print-help)
       (print-help))))
 

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -10,6 +10,8 @@
 
 (import java.net.URLEncoder)
 
+(def version "0.0.29")
+
 (def windows? (str/includes? (System/getProperty "os.name") "Windows"))
 
 (defn url-encode [s] (URLEncoder/encode s "UTF-8"))


### PR DESCRIPTION
Approach:

- Add a new `bb run sync-version` to sync version from `version.txt` to a var in `src/babashka/neil.clj`
- Run `sync-version` on `bb run publish`
- Add entrypoint for `neil --version` that simply prints the var.