### PR TITLE
Fallback to git deps for `neil dep add LIB`

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -2,9 +2,10 @@
                     [clojure.string :as str]
                     [selmer.parser :as p]
                     [selmer.util :refer [without-escaping]])
-         gen-script (let [prelude (slurp "prelude")
-                          script (slurp "src/babashka/neil.clj")]
-                      (spit "neil" (str/join "\n" [prelude script])))
+         gen-script (when (seq (fs/modified-since "neil" #{"prelude" "src/babashka/neil.clj"}))
+                      (let [prelude (slurp "prelude")
+                            script (slurp "src/babashka/neil.clj")]
+                        (spit "neil" (str/join "\n" [prelude script]))))
          update-readme {:depends [gen-script]
                         :task (let [help (:out (shell {:out :string} "./neil"))]
                                (without-escaping

--- a/bb.edn
+++ b/bb.edn
@@ -2,10 +2,9 @@
                     [clojure.string :as str]
                     [selmer.parser :as p]
                     [selmer.util :refer [without-escaping]])
-         gen-script (when (seq (fs/modified-since "neil" #{"prelude" "src/babashka/neil.clj"}))
-                      (let [prelude (slurp "prelude")
-                            script (slurp "src/babashka/neil.clj")]
-                        (spit "neil" (str/join "\n" [prelude script]))))
+         gen-script (let [prelude (slurp "prelude")
+                          script (slurp "src/babashka/neil.clj")]
+                      (spit "neil" (str/join "\n" [prelude script])))
          update-readme {:depends [gen-script]
                         :task (let [help (:out (shell {:out :string} "./neil"))]
                                (without-escaping

--- a/neil
+++ b/neil
@@ -270,15 +270,17 @@
         edn-nodes (edn-nodes edn-string)
         lib (:lib opts)
         lib (symbol lib)
-        git? (or (:sha opts)
-                 (:latest-sha opts))
+        explicit-git? (or (:sha opts)
+                          (:latest-sha opts))
+        [version git?] (if explicit-git?
+                         [(or (:sha opts)
+                              (latest-github-sha lib)) true]
+                         (cond
+                           (:version opts) [(:version opts) false]
+                           (latest-clojars-version lib) [(latest-clojars-version lib) false]
+                           (latest-mvn-version lib) [(latest-mvn-version lib) false]
+                           (latest-github-sha lib) [(latest-github-sha lib) true]))
         mvn? (not git?)
-        version (if git?
-                  (or (:sha opts)
-                      (latest-github-sha lib))
-                  (or (:version opts)
-                      (latest-clojars-version lib)
-                      (latest-mvn-version lib)))
         git-url (when git?
                   (or (:git/url opts)
                       (str "https://github.com/" (clean-github-lib lib))))

--- a/neil
+++ b/neil
@@ -275,11 +275,15 @@
         [version git?] (if explicit-git?
                          [(or (:sha opts)
                               (latest-github-sha lib)) true]
-                         (cond
-                           (:version opts) [(:version opts) false]
-                           (latest-clojars-version lib) [(latest-clojars-version lib) false]
-                           (latest-mvn-version lib) [(latest-mvn-version lib) false]
-                           (latest-github-sha lib) [(latest-github-sha lib) true]))
+                         (or
+                          (when-let [v (:version opts)]
+                            [v false])
+                          (when-let [v (latest-clojars-version lib)]
+                            [v false])
+                          (when-let [v (latest-mvn-version lib)]
+                            [v false])
+                          (when-let [v (latest-github-sha lib)]
+                            [v true])))
         mvn? (not git?)
         git-url (when git?
                   (or (:git/url opts)

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -263,11 +263,15 @@
         [version git?] (if explicit-git?
                          [(or (:sha opts)
                               (latest-github-sha lib)) true]
-                         (cond
-                           (:version opts) [(:version opts) false]
-                           (latest-clojars-version lib) [(latest-clojars-version lib) false]
-                           (latest-mvn-version lib) [(latest-mvn-version lib) false]
-                           (latest-github-sha lib) [(latest-github-sha lib) true]))
+                         (or
+                          (when-let [v (:version opts)]
+                            [v false])
+                          (when-let [v (latest-clojars-version lib)]
+                            [v false])
+                          (when-let [v (latest-mvn-version lib)]
+                            [v false])
+                          (when-let [v (latest-github-sha lib)]
+                            [v true])))
         mvn? (not git?)
         git-url (when git?
                   (or (:git/url opts)

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -258,15 +258,17 @@
         edn-nodes (edn-nodes edn-string)
         lib (:lib opts)
         lib (symbol lib)
-        git? (or (:sha opts)
-                 (:latest-sha opts))
+        explicit-git? (or (:sha opts)
+                          (:latest-sha opts))
+        [version git?] (if explicit-git?
+                         [(or (:sha opts)
+                              (latest-github-sha lib)) true]
+                         (cond
+                           (:version opts) [(:version opts) false]
+                           (latest-clojars-version lib) [(latest-clojars-version lib) false]
+                           (latest-mvn-version lib) [(latest-mvn-version lib) false]
+                           (latest-github-sha lib) [(latest-github-sha lib) true]))
         mvn? (not git?)
-        version (if git?
-                  (or (:sha opts)
-                      (latest-github-sha lib))
-                  (or (:version opts)
-                      (latest-clojars-version lib)
-                      (latest-mvn-version lib)))
         git-url (when git?
                   (or (:git/url opts)
                       (str "https://github.com/" (clean-github-lib lib))))


### PR DESCRIPTION
First - there's the question on whether we should error or fall back if a dependency is not found in Clojars or Maven. This PR assumes we want to fall back to github deps.

---

Rationale - Easier to use CLI to add git deps if one doesn't have to remember specific commands for git deps.

Logic for adding git deps: if library is not found in Clojars or Maven, try git deps.