### PR TITLE
Fix regression in `neil new --name foo` use case

### DIFF
--- a/neil
+++ b/neil
@@ -255,8 +255,8 @@ options can be used to control the add-deps behavior:
   To support the dry run feature, side-effects should be described in the plan
   provided by deps-new-plan. This function's job is to execute side-effects
   using the plan to provide repeatability."
-  [{:keys [opts cmds]}]
-  (if (or (:help opts) (= cmds ["new"]))
+  [{:keys [opts]}]
+  (if (or (:help opts) (not (:name opts)))
     (print-new-help)
     (do
       (require 'org.corfield.new)

--- a/src/babashka/neil/new.clj
+++ b/src/babashka/neil/new.clj
@@ -183,8 +183,8 @@ options can be used to control the add-deps behavior:
   To support the dry run feature, side-effects should be described in the plan
   provided by deps-new-plan. This function's job is to execute side-effects
   using the plan to provide repeatability."
-  [{:keys [opts cmds]}]
-  (if (or (:help opts) (= cmds ["new"]))
+  [{:keys [opts]}]
+  (if (or (:help opts) (not (:name opts)))
     (print-new-help)
     (do
       (require 'org.corfield.new)

--- a/tests.clj
+++ b/tests.clj
@@ -101,6 +101,17 @@
     (let [{:keys [out]} @(process cmd {:out :string})]
       (is (str/starts-with? out "Usage: neil new")))))
 
+(deftest new-name-only-test
+  (let [target-dir (str (fs/temp-dir) "/my-scratch")]
+    (spit (test-file "deps.edn") "{}")
+    (let [edn (run-new-command ":name" "my-scratch"
+                               ":target-dir" target-dir
+                               ":dry-run" "true")]
+      (is (= {:create-opts {:template "scratch"
+                            :target-dir target-dir
+                            :name "my-scratch"}}
+             edn)))))
+
 (deftest new-scratch-test
   (let [target-dir (str (fs/temp-dir) "/my-scratch")]
     (spit (test-file "deps.edn") "{}")


### PR DESCRIPTION
I realized my solution in https://github.com/babashka/neil/pull/61 broke the `neil new --name foo` use case, making it show the help instead of using the `scratch` template. I added a test and changed the implementation to fix this issue.