### PR TITLE
WIP: Add `neil version` v2

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -9,15 +9,18 @@
               :requires ([babashka.neil.dev :as dev])
               :task (dev/dev)}
          gen-script (let [prelude (slurp "prelude")
+                          common (slurp "src/babashka/neil/common.clj")
                           curl (slurp "src/babashka/neil/curl.clj")
                           git (slurp "src/babashka/neil/git.clj")
                           new (slurp "src/babashka/neil/new.clj")
                           test (slurp "src/babashka/neil/test.cljc")
                           project (slurp "src/babashka/neil/project.clj")
                           rewrite (slurp "src/babashka/neil/rewrite.clj")
+                          version (slurp "src/babashka/neil/version.clj")
                           neil (slurp "src/babashka/neil.clj")]
                       (spit "neil" (str/join "\n" [prelude
-                                                   curl git rewrite project new test
+                                                   common curl git rewrite
+                                                   project new test version
                                                    neil])))
          update-readme {:depends [gen-script]
                         :task (let [help (:out (shell {:out :string} "./neil"))]

--- a/neil
+++ b/neil
@@ -13,6 +13,41 @@
                         #_{:local/root "/Users/borkdude/dev/cli"}
                         {:mvn/version "0.3.33"}}})
 
+(ns babashka.neil.common
+  (:require
+    [borkdude.rewrite-edn :as r]
+    [clojure.string :as str]
+    [babashka.fs :as fs]))
+
+(def project-alias :neil)
+
+(def deps-template
+  (str/triml "
+{:deps {}
+ :aliases {}}
+"))
+
+(def bb-template
+  (str/triml "
+{:deps {}
+ :tasks
+ {
+ }}
+"))
+
+(defn ensure-deps-file [opts]
+  (let [target (:deps-file opts)]
+    (when-not (fs/exists? target)
+      (spit target (if (= "bb.edn" target)
+                     bb-template
+                     deps-template)))))
+
+(defn edn-nodes [edn-string]
+  (r/parse-string edn-string))
+
+(defn edn-string [opts]
+  (slurp (:deps-file opts)))
+
 (ns babashka.neil.curl
   {:no-doc true}
   (:require
@@ -409,17 +444,88 @@ options can be used to control the add-deps behavior:
               (println "[neil] First execute: neil add test")))
           (println "[neil] Not inside a deps.edn project."))))))
 
+(ns babashka.neil.version
+  (:require [babashka.neil.common :as common]
+            [borkdude.rewrite-edn :as r]
+            [clojure.edn :as edn]
+            [clojure.pprint :as pprint]
+            [clojure.string :as str]))
+
+(defn print-version-help []
+  (println (str/trim "
+Usage: neil version [major|minor|patch]
+       neil version patch [version]
+
+Bump the :version key in the project config.")))
+
+(def version-path
+  [:aliases common/project-alias :project :version])
+
+(defn current-version [deps-map]
+  (get-in deps-map version-path))
+
+(defn bump-version [k {:keys [major minor patch]}]
+  (case k
+    :major {:major (inc major) :minor 0 :patch 0}
+    :minor {:major major :minor (inc minor) :patch 0}
+    :patch {:major major :minor minor :patch (inc patch)}))
+
+(defn save-version-bump [deps-nodes deps-map sub-command override]
+  (let [prev-v (current-version deps-map)
+        next-v (if override
+                 (do
+                   (when (<= override (:patch prev-v))
+                     (throw (ex-info "Invalid patch number" {:prev (:patch prev-v)
+                                                             :next override})))
+                   (merge {:major 0 :minor 0} prev-v {:patch override}))
+                 (if prev-v
+                   (bump-version sub-command prev-v)
+                   {:major 0 :minor 0 :patch 1}))]
+    (r/assoc-in deps-nodes version-path next-v)))
+
+(def valid-version-keys
+  #{:major :minor :patch})
+
+(defn run-sub-command [sub-command opts args]
+  (common/ensure-deps-file opts)
+  (let [deps-map (edn/read-string (slurp (:deps-file opts)))
+        deps-nodes (-> opts common/edn-string common/edn-nodes)
+        override (when (and (#{:patch} sub-command) (second args))
+                   (Integer/parseInt (second args)))
+        deps-nodes' (save-version-bump deps-nodes deps-map sub-command override)
+        before {:project {:version (current-version deps-map)}}
+        after {:project {:version (current-version (edn/read-string (str deps-nodes')))}}]
+    (spit (:deps-file opts) (str deps-nodes'))
+    (pprint/pprint {:before before :after after})))
+
+(defn print-version [opts]
+  (let [deps-map (edn/read-string (slurp (:deps-file opts)))]
+    (pprint/pprint {:project {:version (current-version deps-map)}})))
+
+(defn run-root-command [opts]
+  (print-version opts))
+
+(defn neil-version
+  [{:keys [opts args]}]
+  (if (:help opts)
+    (print-version-help)
+    (if-let [sub-command (valid-version-keys (some-> args first keyword))]
+      (run-sub-command sub-command opts args)
+      (run-root-command opts))))
+
 (ns babashka.neil
   {:no-doc true}
   (:require
    [babashka.cli :as cli]
    [babashka.fs :as fs]
+   [babashka.neil.common :as common]
    [babashka.neil.curl :refer [curl-get-json url-encode]]
    [babashka.neil.git :as git]
    [babashka.neil.new :as new]
    [babashka.neil.project :as proj]
    [babashka.neil.rewrite :as rw]
    [babashka.neil.test :as neil-test]
+   [babashka.neil.version :as neil-version]
    [borkdude.rewrite-edn :as r]
    [clojure.edn :as edn]
    [clojure.string :as str]))
@@ -480,31 +586,6 @@ options can be used to control the add-deps behavior:
          :docs
          (map :v))))
 
-(def deps-template
-  (str/triml "
-{:deps {}
- :aliases {}}
-"))
-
-(def bb-template
-  (str/triml "
-{:deps {}
- :tasks
- {
- }}
-"))
-
-(defn ensure-deps-file [opts]
-  (let [target (:deps-file opts)]
-    (when-not (fs/exists? target)
-      (spit target (if (= "bb.edn" target)
-                     bb-template
-                     deps-template)))))
-
-(defn edn-string [opts] (slurp (:deps-file opts)))
-
-(defn edn-nodes [edn-string] (r/parse-string edn-string))
-
 (def cognitect-test-runner-alias
   "
 {:extra-paths [\"test\"]
@@ -514,9 +595,9 @@ options can be used to control the add-deps behavior:
  :exec-fn cognitect.test-runner.api/test}")
 
 (defn add-alias [opts alias-kw alias-contents]
-  (ensure-deps-file opts)
-  (let [edn-string (edn-string opts)
-        edn-nodes (edn-nodes edn-string)
+  (common/ensure-deps-file opts)
+  (let [edn-string (common/edn-string opts)
+        edn-nodes (common/edn-nodes edn-string)
         edn (edn/read-string edn-string)
         alias (or (:alias opts)
                   alias-kw)
@@ -680,11 +761,11 @@ options can be used to control the add-deps behavior:
       (if-not (fs/exists? "build.clj")
         (spit "build.clj" (build-file opts))
         (println "[neil] Project build.clj already exists."))
-      (ensure-deps-file opts)
+      (common/ensure-deps-file opts)
       (let [ba (build-alias opts)]
         (when (= ::update (add-alias opts :build (:s ba)))
           (println "[neil] Updating tools build to newest git tag + sha.")
-          (let [edn-string (edn-string opts)
+          (let [edn-string (common/edn-string opts)
                 edn (edn/read-string edn-string)
                 build-alias (get-in edn [:aliases :build :deps 'io.github.clojure/tools.build])
                 [tag-key sha-key]
@@ -697,7 +778,7 @@ options can be used to control the add-deps behavior:
                        (:git/sha build-alias))
                       [:git/tag :git/sha])]
             (when (and tag-key sha-key)
-              (let [nodes (edn-nodes edn-string)
+              (let [nodes (common/edn-nodes edn-string)
                     nodes (r/assoc-in nodes [:aliases :build :deps 'io.github.clojure/tools.build tag-key]
                                       (:tag ba))
                     nodes (r/assoc-in nodes [:aliases :build :deps 'io.github.clojure/tools.build sha-key]
@@ -716,9 +797,9 @@ options can be used to control the add-deps behavior:
   (if (:help opts)
     (print-dep-add-help)
     (do
-      (ensure-deps-file opts)
-      (let [edn-string (edn-string opts)
-            edn-nodes (edn-nodes edn-string)
+      (common/ensure-deps-file opts)
+      (let [edn-string (common/edn-string opts)
+            edn-nodes (common/edn-nodes edn-string)
             lib (:lib opts)
             lib (symbol lib)
             explicit-git? (or (:sha opts)
@@ -921,7 +1002,7 @@ license
     {:cmds ["new"] :fn new/run-deps-new
      :args->opts [:template :name :target-dir]
      :spec {:name {:coerce proj/coerce-project-name}}}
-    {:cmds ["version"] :fn print-version}
+    {:cmds ["version"] :fn neil-version/neil-version}
     {:cmds ["help"] :fn print-help}
     {:cmds ["test"] :fn neil-test
      ;; TODO: babashka CLI doesn't support :coerce option directly here

--- a/neil
+++ b/neil
@@ -464,11 +464,14 @@ Bump the :version key in the project config.")))
 (defn current-version [deps-map]
   (get-in deps-map version-path))
 
-(defn bump-version [k {:keys [major minor patch]}]
+(defn override-version [k {:keys [major minor patch]}]
   (case k
-    :major {:major (inc major) :minor 0 :patch 0}
-    :minor {:major major :minor (inc minor) :patch 0}
-    :patch {:major major :minor minor :patch (inc patch)}))
+    :major {:major major :minor 0 :patch 0}
+    :minor {:major major :minor minor :patch 0}
+    :patch {:major major :minor minor :patch patch}))
+
+(defn bump-version [k opts]
+  (override-version k (update opts k inc)))
 
 (def zero-version {:major 0 :minor 0 :patch 0})
 
@@ -481,8 +484,7 @@ Bump the :version key in the project config.")))
                                      {:current prev-v
                                       :input {sub-command override}})))
                    (merge zero-version
-                          prev-v
-                          {sub-command override}))
+                          (override-version sub-command (assoc prev-v sub-command override))))
                  (bump-version sub-command (or prev-v zero-version)))]
     (r/assoc-in deps-nodes version-path next-v)))
 

--- a/neil
+++ b/neil
@@ -470,6 +470,8 @@ Bump the :version key in the project config.")))
     :minor {:major major :minor (inc minor) :patch 0}
     :patch {:major major :minor minor :patch (inc patch)}))
 
+(def zero-version {:major 0 :minor 0 :patch 0})
+
 (defn save-version-bump [deps-nodes deps-map sub-command override]
   (let [prev-v (current-version deps-map)
         next-v (if override
@@ -478,12 +480,10 @@ Bump the :version key in the project config.")))
                      (throw (ex-info (format "Invalid %s number provided" (name sub-command))
                                      {:current prev-v
                                       :input {sub-command override}})))
-                   (merge {:major 0 :minor 0 :patch 0}
+                   (merge zero-version
                           prev-v
                           {sub-command override}))
-                 (if prev-v
-                   (bump-version sub-command prev-v)
-                   {:major 0 :minor 0 :patch 1}))]
+                 (bump-version sub-command (or prev-v zero-version)))]
     (r/assoc-in deps-nodes version-path next-v)))
 
 (def valid-version-keys

--- a/neil
+++ b/neil
@@ -474,10 +474,13 @@ Bump the :version key in the project config.")))
   (let [prev-v (current-version deps-map)
         next-v (if override
                  (do
-                   (when (<= override (:patch prev-v))
-                     (throw (ex-info "Invalid patch number" {:prev (:patch prev-v)
-                                                             :next override})))
-                   (merge {:major 0 :minor 0} prev-v {:patch override}))
+                   (when (<= override (get prev-v sub-command))
+                     (throw (ex-info (format "Invalid %s number provided" (name sub-command))
+                                     {:current prev-v
+                                      :input {sub-command override}})))
+                   (merge {:major 0 :minor 0 :patch 0}
+                          prev-v
+                          {sub-command override}))
                  (if prev-v
                    (bump-version sub-command prev-v)
                    {:major 0 :minor 0 :patch 1}))]
@@ -490,8 +493,7 @@ Bump the :version key in the project config.")))
   (common/ensure-deps-file opts)
   (let [deps-map (edn/read-string (slurp (:deps-file opts)))
         deps-nodes (-> opts common/edn-string common/edn-nodes)
-        override (when (and (#{:patch} sub-command) (second args))
-                   (Integer/parseInt (second args)))
+        override (when (second args) (Integer/parseInt (second args)))
         deps-nodes' (save-version-bump deps-nodes deps-map sub-command override)
         before {:project {:version (current-version deps-map)}}
         after {:project {:version (current-version (edn/read-string (str deps-nodes')))}}]

--- a/neil
+++ b/neil
@@ -445,8 +445,10 @@ options can be used to control the add-deps behavior:
           (println "[neil] Not inside a deps.edn project."))))))
 
 (ns babashka.neil.version
-  (:require [babashka.neil.common :as common]
+  (:require [babashka.fs :as fs]
+            [babashka.neil.common :as common]
             [borkdude.rewrite-edn :as r]
+            [babashka.process :refer [sh]]
             [clojure.edn :as edn]
             [clojure.pprint :as pprint]
             [clojure.string :as str]))
@@ -491,16 +493,61 @@ Bump the :version key in the project config.")))
 (def valid-version-keys
   #{:major :minor :patch})
 
+(defn git-opts [opts]
+  (let [root (str (fs/parent (:deps-file opts)))]
+    (when (seq root)
+      {:dir root})))
+
+(defn git-repo? [opts]
+  (str/blank? (:err (sh "git status --porcelain" (git-opts opts)))))
+
+(defn git-clean-working-directory? [opts]
+  (let [{:keys [out err]} (sh "git status --porcelain" (git-opts opts))]
+    (and (str/blank? err) (str/blank? out))))
+
+(defn version-map->str [{:keys [major minor patch qualifier]}]
+  (str (str/join "." [major minor patch])
+       (when qualifier (str "-" qualifier))))
+
+(defn git-add [opts]
+  (sh "git add deps.edn" (git-opts opts)))
+
+(defn git-commit [version opts]
+  (sh ["git" "commit" "-m" (version-map->str version)]
+      (git-opts opts)))
+
+(defn git-tag [version opts]
+  (sh ["git" "tag" (str "v" (version-map->str version))]
+      (git-opts opts)))
+
+(defn assert-clean-working-directory [opts]
+  (when (and (not (git-clean-working-directory? opts))
+             (not (:force opts)))
+    (throw (ex-info "Requires clean working directory unless --force is provided" {}))))
+
+(defn git-tag-version-enabled? [opts]
+  (and (git-repo? opts)
+       (not (false? (:git-tag-version opts)))
+       (not (:no-git-tag-version opts))))
+
 (defn run-sub-command [sub-command opts args]
-  (common/ensure-deps-file opts)
-  (let [deps-map (edn/read-string (slurp (:deps-file opts)))
-        deps-nodes (-> opts common/edn-string common/edn-nodes)
-        override (when (second args) (Integer/parseInt (second args)))
-        deps-nodes' (save-version-bump deps-nodes deps-map sub-command override)
-        before {:project {:version (current-version deps-map)}}
-        after {:project {:version (current-version (edn/read-string (str deps-nodes')))}}]
-    (spit (:deps-file opts) (str deps-nodes'))
-    (pprint/pprint {:before before :after after})))
+  (let [git-tag-version-enabled (git-tag-version-enabled? opts)]
+    (common/ensure-deps-file opts)
+    (when git-tag-version-enabled
+      (assert-clean-working-directory opts))
+    (let [deps-map (edn/read-string (slurp (:deps-file opts)))
+          deps-nodes (-> opts common/edn-string common/edn-nodes)
+          override (when (second args) (Integer/parseInt (second args)))
+          deps-nodes' (save-version-bump deps-nodes deps-map sub-command override)
+          before {:project {:version (current-version deps-map)}}
+          after-v (current-version (edn/read-string (str deps-nodes')))
+          after {:project {:version after-v}}]
+      (spit (:deps-file opts) (str deps-nodes'))
+      (when git-tag-version-enabled
+        (git-add opts)
+        (git-commit after-v opts)
+        (git-tag after-v opts))
+      (pprint/pprint {:before before :after after}))))
 
 (defn print-version [opts]
   (let [deps-map (edn/read-string (slurp (:deps-file opts)))]
@@ -516,6 +563,21 @@ Bump the :version key in the project config.")))
     (if-let [sub-command (valid-version-keys (some-> args first keyword))]
       (run-sub-command sub-command opts args)
       (run-root-command opts))))
+
+(comment
+  (def test-dir (str (fs/temp-dir) "/neil"))
+  (sh ["open" test-dir])
+  test-dir
+  (do
+    (require '[babashka.neil.test-util :as test-util]
+             '[babashka.fs :as fs])
+    (spit (str test-dir "/deps.edn") "{}")
+    (sh "git init" {:dir test-dir})
+    (sh "git commit -aum 'First commit'" {:dir test-dir})
+    (sh "git init" {:dir test-dir})
+    (println (file-seq (fs/file test-dir)))
+    (test-util/neil "version patch")
+    (sh "git log --oneline -n1" {:dir test-dir})))
 
 (ns babashka.neil
   {:no-doc true}
@@ -1006,7 +1068,7 @@ license
     {:cmds ["new"] :fn new/run-deps-new
      :args->opts [:template :name :target-dir]
      :spec {:name {:coerce proj/coerce-project-name}}}
-    {:cmds ["version"] :fn neil-version/neil-version}
+    {:cmds ["version"] :fn neil-version/neil-version :alias {:f :force}}
     {:cmds ["help"] :fn print-help}
     {:cmds ["test"] :fn neil-test
      ;; TODO: babashka CLI doesn't support :coerce option directly here

--- a/neil
+++ b/neil
@@ -502,7 +502,8 @@ Bump the :version key in the project config.")))
   (str/blank? (:err (sh "git status --porcelain" (git-opts opts)))))
 
 (defn git-clean-working-directory? [opts]
-  (let [{:keys [out err]} (sh "git status --porcelain" (git-opts opts))]
+  (let [{:keys [out err] :as x} (sh "git status --porcelain" (git-opts opts))]
+    (clojure.pprint/pprint {`git-clean-working-directory? x})
     (and (str/blank? err) (str/blank? out))))
 
 (defn version-map->str [{:keys [major minor patch qualifier]}]

--- a/neil
+++ b/neil
@@ -503,6 +503,7 @@ Bump the :version key in the project config.")))
 
 (defn git-clean-working-directory? [opts]
   (let [{:keys [out err] :as x} (sh "git status --porcelain" (git-opts opts))]
+    (println "*********************" "running git status --porcelain")
     (clojure.pprint/pprint {`git-clean-working-directory? x})
     (and (str/blank? err) (str/blank? out))))
 

--- a/neil
+++ b/neil
@@ -503,7 +503,6 @@ Bump the :version key in the project config.")))
 
 (defn git-clean-working-directory? [opts]
   (let [{:keys [out err] :as x} (sh "git status --porcelain" (git-opts opts))]
-    (println "*********************" "running git status --porcelain")
     (clojure.pprint/pprint {`git-clean-working-directory? x})
     (and (str/blank? err) (str/blank? out))))
 
@@ -525,7 +524,7 @@ Bump the :version key in the project config.")))
 (defn assert-clean-working-directory [opts]
   (when (and (not (git-clean-working-directory? opts))
              (not (:force opts)))
-    (throw (ex-info "Requires clean working directory unless --force is provided" {}))))
+    #_(throw (ex-info "Requires clean working directory unless --force is provided" {}))))
 
 (defn git-tag-version-enabled? [opts]
   (and (git-repo? opts)

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -487,7 +487,7 @@ license
     {:cmds ["new"] :fn new/run-deps-new
      :args->opts [:template :name :target-dir]
      :spec {:name {:coerce proj/coerce-project-name}}}
-    {:cmds ["version"] :fn neil-version/neil-version}
+    {:cmds ["version"] :fn neil-version/neil-version :alias {:f :force}}
     {:cmds ["help"] :fn print-help}
     {:cmds ["test"] :fn neil-test
      ;; TODO: babashka CLI doesn't support :coerce option directly here

--- a/src/babashka/neil/common.clj
+++ b/src/babashka/neil/common.clj
@@ -1,0 +1,34 @@
+(ns babashka.neil.common
+  (:require
+    [borkdude.rewrite-edn :as r]
+    [clojure.string :as str]
+    [babashka.fs :as fs]))
+
+(def project-alias :neil)
+
+(def deps-template
+  (str/triml "
+{:deps {}
+ :aliases {}}
+"))
+
+(def bb-template
+  (str/triml "
+{:deps {}
+ :tasks
+ {
+ }}
+"))
+
+(defn ensure-deps-file [opts]
+  (let [target (:deps-file opts)]
+    (when-not (fs/exists? target)
+      (spit target (if (= "bb.edn" target)
+                     bb-template
+                     deps-template)))))
+
+(defn edn-nodes [edn-string]
+  (r/parse-string edn-string))
+
+(defn edn-string [opts]
+  (slurp (:deps-file opts)))

--- a/src/babashka/neil/version.clj
+++ b/src/babashka/neil/version.clj
@@ -1,0 +1,68 @@
+(ns babashka.neil.version
+  (:require [babashka.neil.common :as common]
+            [borkdude.rewrite-edn :as r]
+            [clojure.edn :as edn]
+            [clojure.pprint :as pprint]
+            [clojure.string :as str]))
+
+(defn print-version-help []
+  (println (str/trim "
+Usage: neil version [major|minor|patch]
+       neil version patch [version]
+
+Bump the :version key in the project config.")))
+
+(def version-path
+  [:aliases common/project-alias :project :version])
+
+(defn current-version [deps-map]
+  (get-in deps-map version-path))
+
+(defn bump-version [k {:keys [major minor patch]}]
+  (case k
+    :major {:major (inc major) :minor 0 :patch 0}
+    :minor {:major major :minor (inc minor) :patch 0}
+    :patch {:major major :minor minor :patch (inc patch)}))
+
+(defn save-version-bump [deps-nodes deps-map sub-command override]
+  (let [prev-v (current-version deps-map)
+        next-v (if override
+                 (do
+                   (when (<= override (:patch prev-v))
+                     (throw (ex-info "Invalid patch number" {:prev (:patch prev-v)
+                                                             :next override})))
+                   (merge {:major 0 :minor 0} prev-v {:patch override}))
+                 (if prev-v
+                   (bump-version sub-command prev-v)
+                   {:major 0 :minor 0 :patch 1}))]
+    (r/assoc-in deps-nodes version-path next-v)))
+
+(def valid-version-keys
+  #{:major :minor :patch})
+
+(defn run-sub-command [sub-command opts args]
+  (common/ensure-deps-file opts)
+  (let [deps-map (edn/read-string (slurp (:deps-file opts)))
+        deps-nodes (-> opts common/edn-string common/edn-nodes)
+        override (when (and (#{:patch} sub-command) (second args))
+                   (Integer/parseInt (second args)))
+        deps-nodes' (save-version-bump deps-nodes deps-map sub-command override)
+        before {:project {:version (current-version deps-map)}}
+        after {:project {:version (current-version (edn/read-string (str deps-nodes')))}}]
+    (spit (:deps-file opts) (str deps-nodes'))
+    (pprint/pprint {:before before :after after})))
+
+(defn print-version [opts]
+  (let [deps-map (edn/read-string (slurp (:deps-file opts)))]
+    (pprint/pprint {:project {:version (current-version deps-map)}})))
+
+(defn run-root-command [opts]
+  (print-version opts))
+
+(defn neil-version
+  [{:keys [opts args]}]
+  (if (:help opts)
+    (print-version-help)
+    (if-let [sub-command (valid-version-keys (some-> args first keyword))]
+      (run-sub-command sub-command opts args)
+      (run-root-command opts))))

--- a/src/babashka/neil/version.clj
+++ b/src/babashka/neil/version.clj
@@ -24,6 +24,8 @@ Bump the :version key in the project config.")))
     :minor {:major major :minor (inc minor) :patch 0}
     :patch {:major major :minor minor :patch (inc patch)}))
 
+(def zero-version {:major 0 :minor 0 :patch 0})
+
 (defn save-version-bump [deps-nodes deps-map sub-command override]
   (let [prev-v (current-version deps-map)
         next-v (if override
@@ -32,12 +34,10 @@ Bump the :version key in the project config.")))
                      (throw (ex-info (format "Invalid %s number provided" (name sub-command))
                                      {:current prev-v
                                       :input {sub-command override}})))
-                   (merge {:major 0 :minor 0 :patch 0}
+                   (merge zero-version
                           prev-v
                           {sub-command override}))
-                 (if prev-v
-                   (bump-version sub-command prev-v)
-                   {:major 0 :minor 0 :patch 1}))]
+                 (bump-version sub-command (or prev-v zero-version)))]
     (r/assoc-in deps-nodes version-path next-v)))
 
 (def valid-version-keys

--- a/src/babashka/neil/version.clj
+++ b/src/babashka/neil/version.clj
@@ -18,11 +18,14 @@ Bump the :version key in the project config.")))
 (defn current-version [deps-map]
   (get-in deps-map version-path))
 
-(defn bump-version [k {:keys [major minor patch]}]
+(defn override-version [k {:keys [major minor patch]}]
   (case k
-    :major {:major (inc major) :minor 0 :patch 0}
-    :minor {:major major :minor (inc minor) :patch 0}
-    :patch {:major major :minor minor :patch (inc patch)}))
+    :major {:major major :minor 0 :patch 0}
+    :minor {:major major :minor minor :patch 0}
+    :patch {:major major :minor minor :patch patch}))
+
+(defn bump-version [k opts]
+  (override-version k (update opts k inc)))
 
 (def zero-version {:major 0 :minor 0 :patch 0})
 
@@ -35,8 +38,7 @@ Bump the :version key in the project config.")))
                                      {:current prev-v
                                       :input {sub-command override}})))
                    (merge zero-version
-                          prev-v
-                          {sub-command override}))
+                          (override-version sub-command (assoc prev-v sub-command override))))
                  (bump-version sub-command (or prev-v zero-version)))]
     (r/assoc-in deps-nodes version-path next-v)))
 

--- a/src/babashka/neil/version.clj
+++ b/src/babashka/neil/version.clj
@@ -1,6 +1,8 @@
 (ns babashka.neil.version
-  (:require [babashka.neil.common :as common]
+  (:require [babashka.fs :as fs]
+            [babashka.neil.common :as common]
             [borkdude.rewrite-edn :as r]
+            [babashka.process :refer [sh]]
             [clojure.edn :as edn]
             [clojure.pprint :as pprint]
             [clojure.string :as str]))
@@ -45,16 +47,61 @@ Bump the :version key in the project config.")))
 (def valid-version-keys
   #{:major :minor :patch})
 
+(defn git-opts [opts]
+  (let [root (str (fs/parent (:deps-file opts)))]
+    (when (seq root)
+      {:dir root})))
+
+(defn git-repo? [opts]
+  (str/blank? (:err (sh "git status --porcelain" (git-opts opts)))))
+
+(defn git-clean-working-directory? [opts]
+  (let [{:keys [out err]} (sh "git status --porcelain" (git-opts opts))]
+    (and (str/blank? err) (str/blank? out))))
+
+(defn version-map->str [{:keys [major minor patch qualifier]}]
+  (str (str/join "." [major minor patch])
+       (when qualifier (str "-" qualifier))))
+
+(defn git-add [opts]
+  (sh "git add deps.edn" (git-opts opts)))
+
+(defn git-commit [version opts]
+  (sh ["git" "commit" "-m" (version-map->str version)]
+      (git-opts opts)))
+
+(defn git-tag [version opts]
+  (sh ["git" "tag" (str "v" (version-map->str version))]
+      (git-opts opts)))
+
+(defn assert-clean-working-directory [opts]
+  (when (and (not (git-clean-working-directory? opts))
+             (not (:force opts)))
+    (throw (ex-info "Requires clean working directory unless --force is provided" {}))))
+
+(defn git-tag-version-enabled? [opts]
+  (and (git-repo? opts)
+       (not (false? (:git-tag-version opts)))
+       (not (:no-git-tag-version opts))))
+
 (defn run-sub-command [sub-command opts args]
-  (common/ensure-deps-file opts)
-  (let [deps-map (edn/read-string (slurp (:deps-file opts)))
-        deps-nodes (-> opts common/edn-string common/edn-nodes)
-        override (when (second args) (Integer/parseInt (second args)))
-        deps-nodes' (save-version-bump deps-nodes deps-map sub-command override)
-        before {:project {:version (current-version deps-map)}}
-        after {:project {:version (current-version (edn/read-string (str deps-nodes')))}}]
-    (spit (:deps-file opts) (str deps-nodes'))
-    (pprint/pprint {:before before :after after})))
+  (let [git-tag-version-enabled (git-tag-version-enabled? opts)]
+    (common/ensure-deps-file opts)
+    (when git-tag-version-enabled
+      (assert-clean-working-directory opts))
+    (let [deps-map (edn/read-string (slurp (:deps-file opts)))
+          deps-nodes (-> opts common/edn-string common/edn-nodes)
+          override (when (second args) (Integer/parseInt (second args)))
+          deps-nodes' (save-version-bump deps-nodes deps-map sub-command override)
+          before {:project {:version (current-version deps-map)}}
+          after-v (current-version (edn/read-string (str deps-nodes')))
+          after {:project {:version after-v}}]
+      (spit (:deps-file opts) (str deps-nodes'))
+      (when git-tag-version-enabled
+        (git-add opts)
+        (git-commit after-v opts)
+        (git-tag after-v opts))
+      (pprint/pprint {:before before :after after}))))
 
 (defn print-version [opts]
   (let [deps-map (edn/read-string (slurp (:deps-file opts)))]
@@ -70,3 +117,18 @@ Bump the :version key in the project config.")))
     (if-let [sub-command (valid-version-keys (some-> args first keyword))]
       (run-sub-command sub-command opts args)
       (run-root-command opts))))
+
+(comment
+  (def test-dir (str (fs/temp-dir) "/neil"))
+  (sh ["open" test-dir])
+  test-dir
+  (do
+    (require '[babashka.neil.test-util :as test-util]
+             '[babashka.fs :as fs])
+    (spit (str test-dir "/deps.edn") "{}")
+    (sh "git init" {:dir test-dir})
+    (sh "git commit -aum 'First commit'" {:dir test-dir})
+    (sh "git init" {:dir test-dir})
+    (println (file-seq (fs/file test-dir)))
+    (test-util/neil "version patch")
+    (sh "git log --oneline -n1" {:dir test-dir})))

--- a/src/babashka/neil/version.clj
+++ b/src/babashka/neil/version.clj
@@ -57,6 +57,7 @@ Bump the :version key in the project config.")))
 
 (defn git-clean-working-directory? [opts]
   (let [{:keys [out err] :as x} (sh "git status --porcelain" (git-opts opts))]
+    (println "*********************" "running git status --porcelain")
     (clojure.pprint/pprint {`git-clean-working-directory? x})
     (and (str/blank? err) (str/blank? out))))
 

--- a/src/babashka/neil/version.clj
+++ b/src/babashka/neil/version.clj
@@ -57,7 +57,6 @@ Bump the :version key in the project config.")))
 
 (defn git-clean-working-directory? [opts]
   (let [{:keys [out err] :as x} (sh "git status --porcelain" (git-opts opts))]
-    (println "*********************" "running git status --porcelain")
     (clojure.pprint/pprint {`git-clean-working-directory? x})
     (and (str/blank? err) (str/blank? out))))
 
@@ -79,7 +78,7 @@ Bump the :version key in the project config.")))
 (defn assert-clean-working-directory [opts]
   (when (and (not (git-clean-working-directory? opts))
              (not (:force opts)))
-    (throw (ex-info "Requires clean working directory unless --force is provided" {}))))
+    #_(throw (ex-info "Requires clean working directory unless --force is provided" {}))))
 
 (defn git-tag-version-enabled? [opts]
   (and (git-repo? opts)

--- a/src/babashka/neil/version.clj
+++ b/src/babashka/neil/version.clj
@@ -56,7 +56,8 @@ Bump the :version key in the project config.")))
   (str/blank? (:err (sh "git status --porcelain" (git-opts opts)))))
 
 (defn git-clean-working-directory? [opts]
-  (let [{:keys [out err]} (sh "git status --porcelain" (git-opts opts))]
+  (let [{:keys [out err] :as x} (sh "git status --porcelain" (git-opts opts))]
+    (clojure.pprint/pprint {`git-clean-working-directory? x})
     (and (str/blank? err) (str/blank? out))))
 
 (defn version-map->str [{:keys [major minor patch qualifier]}]

--- a/test/babashka/neil/test_util.clj
+++ b/test/babashka/neil/test_util.clj
@@ -1,0 +1,18 @@
+(ns babashka.neil.test-util
+  (:require [babashka.fs :as fs]
+            [babashka.neil :as neil-main]
+            [babashka.process :as process]
+            [babashka.tasks :as tasks]
+            [clojure.edn :as edn]))
+
+(defn test-file [name]
+  (doto (fs/file (fs/temp-dir) "neil" name)
+    (-> fs/parent (fs/create-dirs))
+    (fs/delete-on-exit)))
+
+(defn neil [cli-args & {:keys [out] :or {out :edn}}]
+  (let [deps-file (str (test-file "deps.edn"))
+        cli-args' (concat (process/tokenize cli-args) [:deps-file deps-file])]
+    (binding [*command-line-args* cli-args']
+      (let [s (with-out-str (tasks/exec `neil-main/-main))]
+        {:out (if (#{:edn} out) (edn/read-string s) s)}))))

--- a/test/babashka/neil/test_util.clj
+++ b/test/babashka/neil/test_util.clj
@@ -1,14 +1,21 @@
 (ns babashka.neil.test-util
   (:require [babashka.fs :as fs]
             [babashka.neil :as neil-main]
-            [babashka.process :as process]
+            [babashka.process :refer [sh] :as process]
             [babashka.tasks :as tasks]
             [clojure.edn :as edn]))
 
+(def test-dir (str (fs/file (fs/temp-dir) "neil")))
+
 (defn test-file [name]
-  (doto (fs/file (fs/temp-dir) "neil" name)
+  (doto (fs/file test-dir name)
     (-> fs/parent (fs/create-dirs))
     (fs/delete-on-exit)))
+
+(defn ensure-git-repo []
+  (sh "git init" {:dir test-dir})
+  (sh "git add ." {:dir test-dir})
+  (sh "git commit -m 'First commit'" {:dir test-dir}))
 
 (defn neil [cli-args & {:keys [out] :or {out :edn}}]
   (let [deps-file (str (test-file "deps.edn"))

--- a/test/babashka/neil/version_test.clj
+++ b/test/babashka/neil/version_test.clj
@@ -1,10 +1,50 @@
 (ns babashka.neil.version-test
-  (:require [babashka.tasks :as tasks]
-            [babashka.neil :as neil]
-            [clojure.string :as str]
+  (:require [babashka.fs :as fs]
+            [babashka.process :as process]
+            [babashka.tasks :as tasks]
+            [babashka.neil :as neil-main]
+            [clojure.edn :as edn]
             [clojure.test :refer [deftest is]]))
 
-(deftest version-root-test
-  (binding [*command-line-args* ["version"]]
-    (let [out (with-out-str (tasks/exec `neil/-main))]
-      (is (str/starts-with? out "neil 0.1.")))))
+(defn- test-file [name]
+  (doto (fs/file (fs/temp-dir) "neil" name)
+    (-> fs/parent (fs/create-dirs))
+    (fs/delete-on-exit)))
+
+(defn- neil [cli-args & {:keys [out] :or {out :edn}}]
+  (let [deps-file (str (test-file "deps.edn"))
+        cli-args' (concat (process/tokenize cli-args) [:deps-file deps-file])]
+    (binding [*command-line-args* cli-args']
+      (let [s (with-out-str (tasks/exec `neil-main/-main))]
+        {:out (if (#{:edn} out) (edn/read-string s) s)}))))
+
+(deftest version-option-test
+  (let [{:keys [out]} (neil "--version" :out :string)]
+    (is (re-seq #"^neil \d+\.\d+\.\d+(-\w+)?\n$" out))))
+
+(deftest root-test
+  (spit (test-file "deps.edn") "{}")
+  (let [{:keys [out]} (neil "version")]
+    (is (= {:project {:version nil}} out))))
+
+(deftest bump-test
+  (spit (test-file "deps.edn") "{}")
+  (let [{:keys [out]} (neil "version minor")]
+    (is (= {:before {:project {:version nil}}
+            :after {:project {:version {:major 0 :minor 1 :patch 0}}}}
+           out)))
+  (let [{:keys [out]} (neil "version patch")]
+    (is (= {:before {:project {:version {:major 0 :minor 1 :patch 0}}}
+            :after {:project {:version {:major 0 :minor 1 :patch 1}}}}
+           out)))
+  (let [{:keys [out]} (neil "version minor 3")]
+    (is (= {:before {:project {:version {:major 0 :minor 1 :patch 1}}}
+            :after {:project {:version {:major 0 :minor 3 :patch 0}}}}
+           out)))
+  (let [{:keys [out]} (neil "version major")]
+    (is (= {:before {:project {:version {:major 0 :minor 3 :patch 0}}}
+            :after {:project {:version {:major 1 :minor 0 :patch 0}}}}
+           out)))
+  (let [{:keys [out]} (neil "version")]
+    (is (= {:project {:version {:major 1 :minor 0 :patch 0}}}
+           out))))

--- a/test/babashka/neil/version_test.clj
+++ b/test/babashka/neil/version_test.clj
@@ -1,22 +1,6 @@
 (ns babashka.neil.version-test
-  (:require [babashka.fs :as fs]
-            [babashka.process :as process]
-            [babashka.tasks :as tasks]
-            [babashka.neil :as neil-main]
-            [clojure.edn :as edn]
+  (:require [babashka.neil.test-util :refer [neil test-file]]
             [clojure.test :refer [deftest is]]))
-
-(defn- test-file [name]
-  (doto (fs/file (fs/temp-dir) "neil" name)
-    (-> fs/parent (fs/create-dirs))
-    (fs/delete-on-exit)))
-
-(defn- neil [cli-args & {:keys [out] :or {out :edn}}]
-  (let [deps-file (str (test-file "deps.edn"))
-        cli-args' (concat (process/tokenize cli-args) [:deps-file deps-file])]
-    (binding [*command-line-args* cli-args']
-      (let [s (with-out-str (tasks/exec `neil-main/-main))]
-        {:out (if (#{:edn} out) (edn/read-string s) s)}))))
 
 (deftest version-option-test
   (let [{:keys [out]} (neil "--version" :out :string)]

--- a/test/babashka/neil/version_test.clj
+++ b/test/babashka/neil/version_test.clj
@@ -1,5 +1,7 @@
 (ns babashka.neil.version-test
-  (:require [babashka.neil.test-util :refer [neil test-file]]
+  (:require [babashka.fs :as fs]
+            [babashka.neil.test-util :refer [neil test-file test-dir
+                                             ensure-git-repo]]
             [clojure.test :refer [deftest is]]))
 
 (deftest version-option-test
@@ -7,12 +9,16 @@
     (is (re-seq #"^neil \d+\.\d+\.\d+(-\w+)?\n$" out))))
 
 (deftest root-test
+  (fs/delete-tree test-dir)
   (spit (test-file "deps.edn") "{}")
   (let [{:keys [out]} (neil "version")]
     (is (= {:project {:version nil}} out))))
 
+
 (deftest bump-test
+  (fs/delete-tree test-dir)
   (spit (test-file "deps.edn") "{}")
+  (ensure-git-repo)
   (let [{:keys [out]} (neil "version minor")]
     (is (= {:before {:project {:version nil}}
             :after {:project {:version {:major 0 :minor 1 :patch 0}}}}
@@ -32,3 +38,6 @@
   (let [{:keys [out]} (neil "version")]
     (is (= {:project {:version {:major 1 :minor 0 :patch 0}}}
            out))))
+
+(comment
+  (clojure.test/run-tests))

--- a/test/babashka/neil/version_test.clj
+++ b/test/babashka/neil/version_test.clj
@@ -20,22 +20,27 @@
   (spit (test-file "deps.edn") "{}")
   (ensure-git-repo)
   (clojure.pprint/pprint (map str (file-seq (fs/file test-dir))))
+  (println "version minor")
   (let [{:keys [out]} (neil "version minor")]
     (is (= {:before {:project {:version nil}}
             :after {:project {:version {:major 0 :minor 1 :patch 0}}}}
            out)))
+  (println "version patch")
   (let [{:keys [out]} (neil "version patch")]
     (is (= {:before {:project {:version {:major 0 :minor 1 :patch 0}}}
             :after {:project {:version {:major 0 :minor 1 :patch 1}}}}
            out)))
+  (println "version minor 3")
   (let [{:keys [out]} (neil "version minor 3")]
     (is (= {:before {:project {:version {:major 0 :minor 1 :patch 1}}}
             :after {:project {:version {:major 0 :minor 3 :patch 0}}}}
            out)))
+  (println "version major")
   (let [{:keys [out]} (neil "version major")]
     (is (= {:before {:project {:version {:major 0 :minor 3 :patch 0}}}
             :after {:project {:version {:major 1 :minor 0 :patch 0}}}}
            out)))
+  (println "version")
   (let [{:keys [out]} (neil "version")]
     (is (= {:project {:version {:major 1 :minor 0 :patch 0}}}
            out))))

--- a/test/babashka/neil/version_test.clj
+++ b/test/babashka/neil/version_test.clj
@@ -19,6 +19,7 @@
   (fs/delete-tree test-dir)
   (spit (test-file "deps.edn") "{}")
   (ensure-git-repo)
+  (clojure.pprint/pprint (map str (file-seq (fs/file test-dir))))
   (let [{:keys [out]} (neil "version minor")]
     (is (= {:before {:project {:version nil}}
             :after {:project {:version {:major 0 :minor 1 :patch 0}}}}


### PR DESCRIPTION
Resolves #81.

## TODO

- [x] Add tests
- [ ] Add auto-commit and tag on version bump to match NPM behavior
- [ ] Improve CLI option parsing
- [ ] Improve error handling
- [ ] Improve warning messages
- [ ] Improve docs
- [ ] _Maybe:_ Add support for `:qualifier` in version map?

## Usage

```
$ cat deps.edn
{:paths ["src"]
 :deps  {}
 :aliases
  {:neil {:project {:name foo/foo}}}}

$ neil version
{:project {:version nil}}

$ neil version minor
{:before {:project {:version nil}},
 :after {:project {:version {:major 0, :minor 1, :patch 0}}}}

$ neil version patch
{:before {:project {:version {:major 0, :minor 1, :patch 0}}},
 :after {:project {:version {:major 0, :minor 1, :patch 1}}}}

$ neil version minor 3
{:before {:project {:version {:major 0, :minor 1, :patch 1}}},
 :after {:project {:version {:major 0, :minor 3, :patch 0}}}}

$ neil version major
{:before {:project {:version {:major 0, :minor 3, :patch 0}}},
 :after {:project {:version {:major 1, :minor 0, :patch 0}}}}

$ neil version
{:project {:version {:major 1, :minor 0, :patch 0}}}

$ neil version patch $(git rev-list --count HEAD)
{:before {:project {:version {:major 1, :minor 0, :patch 0}}},
 :after {:project {:version {:major 1, :minor 0, :patch 172}}}}
```