### PR TITLE
Add `babashka.neil.version-test` with test runner

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -1,4 +1,4 @@
-{:paths ["src" "dev"]
+{:paths ["src" "dev" "test"]
  :pods {org.babashka/fswatcher {:version "0.0.3"}}
  :deps {org.babashka/neil {:local/root "."}}
  :tasks {:requires ([babashka.fs :as fs]
@@ -40,10 +40,8 @@
                                                    (str "(def version \"" version "\")"))]
                         (spit "src/babashka/neil.clj" newsource))
          tests {:depends [gen-script]
-                :task (do (load-file "tests.clj")
-                          (let [{:keys [error fail]} (clojure.test/run-tests 'tests)]
-                            (when (pos? (+ error fail))
-                              (throw (ex-info "Tests failed" {:babashka/exit 1})))))}
+                :requires ([babashka.neil.test-runner])
+                :task (exec 'babashka.neil.test-runner/run-tests)}
          tests-emacs {:extra-paths ["."]
                       :requires ([tests-emacs :as te])
                       :task (te/run-tests)}

--- a/test/babashka/neil/test_runner.clj
+++ b/test/babashka/neil/test_runner.clj
@@ -1,0 +1,22 @@
+(ns babashka.neil.test-runner
+  (:require [babashka.fs :as fs]
+            [clojure.edn :as edn]
+            [clojure.test :as t]))
+
+(load-file (str (fs/parent *file*) "/../../../tests.clj"))
+
+(def test-namespaces
+  '[tests
+    babashka.neil.version-test])
+
+(doseq [ns test-namespaces]
+  (require ns))
+
+(defn run-tests [& {:keys [nses]}]
+  (let [selected-tests (if nses
+                         (edn/read-string nses)
+                         test-namespaces)
+        test-results (apply t/run-tests selected-tests)
+        {:keys [:fail :error]} test-results]
+    (when (pos? (+ fail error))
+      (throw (ex-info "Tests failed" {:babashka/exit 1})))))

--- a/test/babashka/neil/version_test.clj
+++ b/test/babashka/neil/version_test.clj
@@ -1,0 +1,10 @@
+(ns babashka.neil.version-test
+  (:require [babashka.tasks :as tasks]
+            [babashka.neil :as neil]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is]]))
+
+(deftest version-root-test
+  (binding [*command-line-args* ["version"]]
+    (let [out (with-out-str (tasks/exec `neil/-main))]
+      (is (str/starts-with? out "neil 0.1.")))))


### PR DESCRIPTION
- This is the first step towards #85
- Merging this in first will help make the changes for https://github.com/babashka/neil/pull/84 easier to read
- It also shows how we can write tests without the `neil` script while still defining input in terms of babashka CLI

Usage:
```
$ bb tests

Testing tests

Testing babashka.neil.version-test

Ran 13 tests containing 34 assertions.
0 failures, 0 errors.
```
```
$ bb tests :nses '[babashka.neil.version-test]'

Testing babashka.neil.version-test

Ran 1 tests containing 1 assertions.
0 failures, 0 errors.
```