### PR TITLE
Remove conflicting dep

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -5,9 +5,7 @@
         borkdude/rewrite-edn {:mvn/version "0.2.0"}
         org.babashka/cli {:mvn/version "0.3.33"}
         cheshire/cheshire {:mvn/version "5.11.0"}
-        io.github.seancorfield/deps-new {:git/tag "v0.4.13" :git/sha "879c4eb"}
-        org.corfield/deps-new {:git/url "https://github.com/rads/deps-new"
-                               :git/sha "d81f8f533017bea1bf08d482ad9a21bb9fb617be"}}
+        io.github.seancorfield/deps-new {:git/tag "v0.4.13" :git/sha "879c4eb"}}
  :tools/usage {:ns-default babashka.neil.api}
  :aliases {:test ;; added by neil
            {:extra-paths ["test"]


### PR DESCRIPTION
The `org.corfield/deps-new` dep should not be used (in favor of the official `io.github.seancorfield/deps-new` instead).