### PR TITLE
Improvements for `bb dev` task

### DIFF
--- a/dev/babashka/neil/dev.clj
+++ b/dev/babashka/neil/dev.clj
@@ -5,7 +5,7 @@
             [pod.babashka.fswatcher :as fw]
             [taoensso.timbre :as log]))
 
-(def watch-paths ["bb.edn" "prelude" "src"])
+(def watch-paths ["bb.edn" "prelude" "src" "dev"])
 
 (defn- build-event? [{:keys [type path] :as _watch-event}]
   (and (not (#{:chmod} type))

--- a/dev/babashka/neil/dev.clj
+++ b/dev/babashka/neil/dev.clj
@@ -16,7 +16,7 @@
 (defn build-once [event]
   (let [i (swap! build-number inc)]
     (log/info (into [:start-build i event]))
-    (sh "bb gen-script")
+    (sh "bb gen-script" {:err :inherit})
     (log/info (into [:end-build i event]))))
 
 (defn- start-builder [build-events]

--- a/dev/babashka/neil/dev.clj
+++ b/dev/babashka/neil/dev.clj
@@ -33,7 +33,7 @@
   (let [build-xf (filter build-event?)
         build-events (async/chan (async/sliding-buffer 1) build-xf)]
     (log/info [:start-dev])
-    (build-once {:type ::startup-build})
     (start-watchers watch-paths build-events)
+    (build-once {:type ::startup-build})
     (start-builder build-events)
     (deref (promise))))

--- a/dev/babashka/neil/dev.clj
+++ b/dev/babashka/neil/dev.clj
@@ -15,9 +15,9 @@
 
 (defn build-once [event]
   (let [i (swap! build-number inc)]
-    (log/info (into [:start-build i event]))
+    (log/info [:start-build i event])
     (sh "bb gen-script" {:err :inherit})
-    (log/info (into [:end-build i event]))))
+    (log/info [:end-build i event])))
 
 (defn- start-builder [build-events]
   (async/go-loop []

--- a/dev/babashka/neil/dev.clj
+++ b/dev/babashka/neil/dev.clj
@@ -8,8 +8,9 @@
 (def watch-paths ["bb.edn" "prelude" "src" "dev"])
 
 (defn- build-event? [{:keys [type path] :as _watch-event}]
-  (and (not (#{:chmod} type))
-       (not (str/ends-with? path "~"))))
+  (or (#{::start} type)
+      (and (not (#{:chmod} type))
+           (not (str/ends-with? path "~")))))
 
 (defn- start-builder [build-events]
   (async/go-loop [i 1]
@@ -29,4 +30,5 @@
     (log/info [:start-dev])
     (start-builder build-events)
     (start-watchers watch-paths build-events)
+    (async/put! build-events {:type ::start})
     (deref (promise))))


### PR DESCRIPTION
Building the script on initial run is useful when starting `bb dev` after switching branches.