### PR TITLE
Less confusing `neil dep add` helptext

### DIFF
--- a/neil
+++ b/neil
@@ -833,7 +833,7 @@ add
 
 dep
   add: Adds --lib, a fully qualified symbol, to deps.edn :deps.
-    Run neil add dep --help to see all options.
+    Run neil dep add --help to see all options.
 
 new:
   Create a project using deps-new

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -422,7 +422,7 @@ add
 
 dep
   add: Adds --lib, a fully qualified symbol, to deps.edn :deps.
-    Run neil add dep --help to see all options.
+    Run neil dep add --help to see all options.
 
 new:
   Create a project using deps-new


### PR DESCRIPTION
Before: `neil dep add` helptext instructed the user to run `neil add dep`.

After: `neil dep add` helptext instructed the user to run `neil dep add`.