### PR TITLE
Add `neil dep search` to top-level `--help`

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,15 +72,14 @@ add
 
 dep
   add: Adds --lib, a fully qualified symbol, to deps.edn :deps.
-    Run neil add dep --help to see all options.
+    Run `neil dep add --help` to see all options.
+
+  search: Search Clojars for a string in any attribute of an artifact
+    Run `neil dep search --help` to see all options.
 
 new:
   Create a project using deps-new
     Run neil new --help to see all options.
-
-  Examples:
-    neil new scratch foo --overwrite
-    neil new io.github.rads/neil-new-test-template foo2 --latest-sha
 
 test:
   Run tests. Assumes `neil add test`. Run `neil test --help` to see all options.

--- a/neil
+++ b/neil
@@ -834,7 +834,10 @@ add
 
 dep
   add: Adds --lib, a fully qualified symbol, to deps.edn :deps.
-    Run neil dep add --help to see all options.
+    Run `neil dep add --help` to see all options.
+
+  search: Search Clojars for a string in any attribute of an artifact
+    Run `neil dep search --help` to see all options.
 
 new:
   Create a project using deps-new

--- a/neil
+++ b/neil
@@ -312,7 +312,11 @@ options can be used to control the add-deps behavior:
 
   --latest-sha
     Override the :git/sha in the :deps map with the latest SHA from the
-    default branch of :git/url.")))
+    default branch of :git/url.
+
+Examples:
+  neil new scratch foo --overwrite
+  neil new io.github.rads/neil-new-test-template foo2 --latest-sha")))
 
 (defn- deps-new-set-classpath
   "Sets the java.class.path property.
@@ -842,10 +846,6 @@ dep
 new:
   Create a project using deps-new
     Run neil new --help to see all options.
-
-  Examples:
-    neil new scratch foo --overwrite
-    neil new io.github.rads/neil-new-test-template foo2 --latest-sha
 
 test:
   Run tests. Assumes `neil add test`. Run `neil test --help` to see all options.

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -430,10 +430,6 @@ new:
   Create a project using deps-new
     Run neil new --help to see all options.
 
-  Examples:
-    neil new scratch foo --overwrite
-    neil new io.github.rads/neil-new-test-template foo2 --latest-sha
-
 test:
   Run tests. Assumes `neil add test`. Run `neil test --help` to see all options.
 

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -421,7 +421,10 @@ add
 
 dep
   add: Adds --lib, a fully qualified symbol, to deps.edn :deps.
-    Run neil dep add --help to see all options.
+    Run `neil dep add --help` to see all options.
+
+  search: Search Clojars for a string in any attribute of an artifact
+    Run `neil dep search --help` to see all options.
 
 new:
   Create a project using deps-new

--- a/src/babashka/neil/new.clj
+++ b/src/babashka/neil/new.clj
@@ -177,7 +177,11 @@ options can be used to control the add-deps behavior:
 
   --latest-sha
     Override the :git/sha in the :deps map with the latest SHA from the
-    default branch of :git/url.")))
+    default branch of :git/url.
+
+Examples:
+  neil new scratch foo --overwrite
+  neil new io.github.rads/neil-new-test-template foo2 --latest-sha")))
 
 (defn- deps-new-set-classpath
   "Sets the java.class.path property.


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
  - https://github.com/babashka/neil/issues/65
- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/neil/blob/main/CHANGELOG.md) file with a description of the addressed issue.

## Overview

I missed this in my [original PR](https://github.com/babashka/neil/pull/68) for https://github.com/babashka/neil/issues/65. I added the `neil dep search --help` command but I forgot to mention it in the top-level `neil --help` command.

As part of this, I moved the examples for `neil new` from the top-level `neil --help` to the `neil new --help` command. This is something I was thinking about earlier since the examples seem out of place with the rest of the docs here. In this case it also makes things easier to read since we are using a similar indentation for the `neil dep` subcommands.

Let me know if you would like me to update the `CHANGELOG.md` here.