### PR TITLE
Add `bb run ci` task

### DIFF
--- a/.github/workflows/bb-run-lint.yml
+++ b/.github/workflows/bb-run-lint.yml
@@ -9,5 +9,6 @@ jobs:
       - name: Install clojure tools
         uses: DeLaGuardo/setup-clojure@9.4
         with:
+          bb: latest
           clj-kondo: latest
-      - run: clj-kondo --lint .
+      - run: bb run lint

--- a/.github/workflows/bb-run-lint.yml
+++ b/.github/workflows/bb-run-lint.yml
@@ -1,4 +1,4 @@
-name: clj-kondo
+name: bb run lint
 on: [push, pull_request]
 jobs:
   Testing:

--- a/bb.edn
+++ b/bb.edn
@@ -8,6 +8,16 @@
          dev {:doc "Starts watcher to auto-build neil script"
               :requires ([babashka.neil.dev :as dev])
               :task (dev/dev)}
+         ci {:doc "Run all CI tasks locally"
+             :requires ([taoensso.timbre :as log])
+             :task (do
+                     (log/info "bb run lint")
+                     (run 'lint)
+                     (log/info "bb run tests")
+                     (run 'tests)
+                     (log/info "bb run tests-emacs")
+                     (run 'tests-emacs))}
+         lint (shell "clj-kondo --lint .")
          gen-script {:doc "Build the neil script"
                      :requires ([babashka.neil.gen-script :as gen-script])
                      :task (gen-script/gen-script)}


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
  - https://github.com/babashka/neil/issues/100
- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/neil/blob/main/CHANGELOG.md) file with a description of the addressed issue.

## Overview

I noticed I had a CI error after merging in `main` into my other PR. I'm adding the `bb run ci` task so I can run the CI steps locally before pushing to GitHub.

This also includes a change to rename `clj-kondo` workflow to `bb-run-lint` so all the CI commands are encapsulated in `bb.edn`.