### PR TITLE
`neil dep upgrade` - proof of concept

### DIFF
--- a/neil
+++ b/neil
@@ -893,6 +893,50 @@ will return libraries with 'test framework' in their description.")))
   ;; we can fix incrementally later. Getting something working is probably the
   ;; best first step.
   (assert (:dry-run opts) "for now, only dry-run is supported. Nice for dev :)")
+  (let [latest-version (fn [lib]
+                         (->> (or (seq (clojars-versions lib opts))
+                                  (seq (mvn-versions lib opts))
+                                  [])
+                              last))
+        current-deps (-> (edn-string opts)
+                         edn/read-string
+                         :deps)
+        #_#_
+        alternative-deps (->> current-deps
+                              (pmap (fn [[lib _current-version]]
+                                      (let [latest-version (->> (or (seq (clojars-versions lib opts))
+                                                                    (seq (mvn-versions lib opts))
+                                                                    [])
+                                                                ;; remove alpha and beta versions
+                                                                ;; not 100 % sure about desired behavior here, but I think people in general
+                                                                ;; want "latest stable"
+                                                                (filter (fn [s]
+                                                                          (re-matches #"[0-9\.]+" s)))
+                                                                last)]
+                                        [lib latest-version])))
+                              (into {}))]
+    #_
+    (doseq [[lib currentv] current-deps]
+      (prn [lib currentv (or (mvn-versions lib opts)
+                             (clojars-versions lib opts))]))
+    ;; (prn (clojars-versions 'hiccup/hiccup {}))
+    #_#_#_
+    (println "latest mvn version")
+    (prn (latest-mvn-version 'org.clojure/clojure))
+    (println "latest mvn version done")
+    (doseq [[lib currentv] current-deps]
+      (let [latest (or (latest-clojars-version lib)
+                       (latest-mvn-version lib))]
+        (when (and latest
+                   (not= currentv {:mvn/version latest}))
+          (println :lib lib :version (:mvn/version currentv) :latest latest)
+          )
+
+        )
+      #_
+      (prn [lib currentv (or (mvn-versions lib opts)
+                             (clojars-versions lib opts))]))
+    )
   )
 
 (defn print-help [_]

--- a/neil
+++ b/neil
@@ -874,6 +874,27 @@ will return libraries with 'test framework' in their description.")))
                  :version (:version search-result)
                  :description (pr-str (:description search-result)))))))
 
+(defn dep-upgrade [{:keys [opts]}]
+  ;; Outline:
+  ;;
+  ;; 1. look for existing dependencies in deps.edn
+  ;; 2. pull the latest version for each dep
+  ;;    - ignore versions with non-numeric IDs by default, override with
+  ;;      --allow-on-numeric-versions
+  ;; 3. if --dry-run, print the updated deps, otherwise update the deps.edn file.
+  ;;
+  ;; Potential gotchas with existing supported options:
+  ;;
+  ;;   - :target can be deps.edn or bb.edn
+  ;;   - :alias can be something other than the toplevel
+  ;;   - :deps-file can be something weird
+  ;;
+  ;; There's plenty of example code in the other functions. This is also stuff
+  ;; we can fix incrementally later. Getting something working is probably the
+  ;; best first step.
+  (assert (:dry-run opts) "for now, only dry-run is supported. Nice for dev :)")
+  )
+
 (defn print-help [_]
   (println (str/trim "
 Usage: neil <subcommand> <options>
@@ -971,6 +992,7 @@ license
     {:cmds ["dep" "versions"] :fn dep-versions :args->opts [:lib]}
     {:cmds ["dep" "add"] :fn dep-add :args->opts [:lib]}
     {:cmds ["dep" "search"] :fn dep-search :args->opts [:search-term]}
+    {:cmds ["dep" "upgrade"] :fn dep-upgrade}
     {:cmds ["license" "list"] :fn license-search :args->opts [:search-term]}
     {:cmds ["license" "search"] :fn license-search :args->opts [:search-term]}
     {:cmds ["license" "add"] :fn add-license :args->opts [:license]}

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -418,6 +418,27 @@ will return libraries with 'test framework' in their description.")))
                  :version (:version search-result)
                  :description (pr-str (:description search-result)))))))
 
+(defn dep-upgrade [{:keys [opts]}]
+  ;; Outline:
+  ;;
+  ;; 1. look for existing dependencies in deps.edn
+  ;; 2. pull the latest version for each dep
+  ;;    - ignore versions with non-numeric IDs by default, override with
+  ;;      --allow-on-numeric-versions
+  ;; 3. if --dry-run, print the updated deps, otherwise update the deps.edn file.
+  ;;
+  ;; Potential gotchas with existing supported options:
+  ;;
+  ;;   - :target can be deps.edn or bb.edn
+  ;;   - :alias can be something other than the toplevel
+  ;;   - :deps-file can be something weird
+  ;;
+  ;; There's plenty of example code in the other functions. This is also stuff
+  ;; we can fix incrementally later. Getting something working is probably the
+  ;; best first step.
+  (assert (:dry-run opts) "for now, only dry-run is supported. Nice for dev :)")
+  )
+
 (defn print-help [_]
   (println (str/trim "
 Usage: neil <subcommand> <options>
@@ -515,6 +536,7 @@ license
     {:cmds ["dep" "versions"] :fn dep-versions :args->opts [:lib]}
     {:cmds ["dep" "add"] :fn dep-add :args->opts [:lib]}
     {:cmds ["dep" "search"] :fn dep-search :args->opts [:search-term]}
+    {:cmds ["dep" "upgrade"] :fn dep-upgrade}
     {:cmds ["license" "list"] :fn license-search :args->opts [:search-term]}
     {:cmds ["license" "search"] :fn license-search :args->opts [:search-term]}
     {:cmds ["license" "add"] :fn add-license :args->opts [:license]}

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -437,6 +437,48 @@ will return libraries with 'test framework' in their description.")))
   ;; we can fix incrementally later. Getting something working is probably the
   ;; best first step.
   (assert (:dry-run opts) "for now, only dry-run is supported. Nice for dev :)")
+  (let [latest-version (fn [lib]
+                         (->> (or (seq (clojars-versions lib opts))
+                                  (seq (mvn-versions lib opts))
+                                  [])
+                              last))
+        current-deps (-> (edn-string opts)
+                         edn/read-string
+                         :deps)
+        #_#_
+        alternative-deps (->> current-deps
+                              (pmap (fn [[lib _current-version]]
+                                      (let [latest-version (->> (or (seq (clojars-versions lib opts))
+                                                                    (seq (mvn-versions lib opts))
+                                                                    [])
+                                                                ;; remove alpha and beta versions
+                                                                ;; not 100 % sure about desired behavior here, but I think people in general
+                                                                ;; want "latest stable"
+                                                                (filter (fn [s]
+                                                                          (re-matches #"[0-9\.]+" s)))
+                                                                last)]
+                                        [lib latest-version])))
+                              (into {}))]
+    #_
+    (doseq [[lib currentv] current-deps]
+      (prn [lib currentv (or (mvn-versions lib opts)
+                             (clojars-versions lib opts))]))
+    ;; (prn (clojars-versions 'hiccup/hiccup {}))
+    #_#_#_
+    (println "latest mvn version")
+    (prn (latest-mvn-version 'org.clojure/clojure))
+    (println "latest mvn version done")
+    (doseq [[lib currentv] current-deps]
+      (let [latest (or (latest-clojars-version lib)
+                       (latest-mvn-version lib))]
+        (when (and latest
+                   (not= currentv {:mvn/version latest}))
+          (println :lib lib :version (:mvn/version currentv) :latest latest))
+        )
+      #_
+      (prn [lib currentv (or (mvn-versions lib opts)
+                             (clojars-versions lib opts))]))
+    )
   )
 
 (defn print-help [_]


### PR DESCRIPTION
- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/neil/blob/main/CHANGELOG.md) file with a description of the addressed issue.

Current CLI output, only `--dry-run` is supported:

```
neilz dep upgrade :dry-run
:lib org.babashka/sci :version 0.2.8 :latest 0.3.32
:lib djblue/portal :version 0.19.2 :latest 0.29.1
```