### PR TITLE
`neil version`: Add `set` subcommand

### DIFF
--- a/neil
+++ b/neil
@@ -127,6 +127,10 @@
   (sh "git add ." git-opts)
   (sh "git commit -m 'First commit'" git-opts))
 
+(defn list-tags [git-opts]
+  (let [{:keys [out]} (sh "git tag" git-opts)]
+    (str/split-lines (str/trim out))))
+
 (defn tag-contents [tag git-opts]
   (let [cmd ["git" "for-each-ref" (str "refs/tags/" tag)
              "--format" "%(contents)"]

--- a/neil
+++ b/neil
@@ -610,6 +610,68 @@ Examples:
     (prn {:neil meta/version
           :project (version-map->str project-version-map :prefix false)})))
 
+(defn git-tag-version-enabled? [opts]
+  (and (git/repo? (:deps-file opts))
+       (not (false? (:git-tag-version opts)))
+       (not (false? (:tag opts)))
+       (not (:no-git-tag-version opts))
+       (not (:no-tag opts))))
+
+(defn- set-version! [v {:keys [deps-file] :as _opts}]
+  (proj/assoc-project-meta! {:deps-file deps-file :k :version :v v}))
+
+(defn git-clean-working-directory? [git-status-result]
+  (some->> (:statuses git-status-result)
+           (remove #(re-seq #"^\?" (:status %)))
+           empty?))
+
+(defn assert-clean-working-directory [opts]
+  (when (and (not (git-clean-working-directory? (git/status (git-opts opts))))
+             (not (:force opts)))
+    (throw (ex-info "Requires clean working directory unless --force is provided" {}))))
+
+(def zero-version {:major 0 :minor 0 :patch 0})
+
+(defn strictly-increasing-semver-version? [prev-v next-v]
+  (let [prev-v' (or prev-v zero-version)]
+    (or (< (:major prev-v') (:major next-v))
+        (and (<= (:major prev-v') (:major next-v))
+             (< (:minor prev-v') (:minor next-v)))
+        (and (<= (:major prev-v') (:major next-v))
+             (<= (:minor prev-v') (:minor next-v))
+             (< (:patch prev-v') (:patch next-v))))))
+
+(defn assert-strictly-increasing-semver-version [prev-v next-v]
+  (when-not (strictly-increasing-semver-version? prev-v next-v)
+    (throw (ex-info "Versions in SemVer format must be strictly increasing"
+                    {:current-version (version-map->str prev-v :prefix true)
+                     :input-version (version-map->str next-v :prefix true)}))))
+
+(defn assert-valid-version-change [prev-v next-v]
+  (when (and (semver-version-map? prev-v) (semver-version-map? next-v))
+    (assert-strictly-increasing-semver-version prev-v next-v)))
+
+(defn run-set-command [{:keys [version dir deps-file] :as opts}]
+  (let [deps-file' (proj/resolve-deps-file dir deps-file)
+        opts' (assoc opts :deps-file deps-file')
+        git-tag-version-enabled (git-tag-version-enabled? opts')]
+    (when git-tag-version-enabled
+      (assert-clean-working-directory opts'))
+    (proj/ensure-neil-project opts')
+    (let [deps-edn (some-> deps-file' slurp edn/read-string)
+          prev-version-string (deps-edn->project-version-string deps-edn)
+          prev-version-map (str->version-map prev-version-string)
+          next-version-map (str->version-map version)
+          next-version-string (version-map->str next-version-map :prefix false)
+          next-prefixed-version (version-map->str next-version-map :prefix true)]
+      (assert-valid-version-change prev-version-map next-version-map)
+      (set-version! next-version-string opts')
+      (when git-tag-version-enabled
+        (git/add ["deps.edn"] (git-opts opts'))
+        (git/commit next-prefixed-version (git-opts opts'))
+        (git/tag next-prefixed-version (git-opts opts')))
+      (println next-prefixed-version))))
+
 (defn print-help []
   (println (str/trim "
 Usage: neil version [set|major|minor|patch] [version]
@@ -627,7 +689,8 @@ Bump the :version key in the project config.")))
      (print-help)
      (case command
        :root (run-root-command opts)
-       :tag (run-tag-command opts)))))
+       :tag (run-tag-command opts)
+       :set (run-set-command opts)))))
 
 (ns babashka.neil
   {:no-doc true}
@@ -1154,6 +1217,10 @@ license
      :spec {:name {:coerce proj/coerce-project-name}}}
     {:cmds ["version" "tag"]
      :fn (partial neil-version/neil-version :tag)
+     :aliases {:h :help}}
+    {:cmds ["version" "set"]
+     :fn (partial neil-version/neil-version :set)
+     :args->opts [:version]
      :aliases {:h :help}}
     {:cmds ["version"]
      :fn neil-version/neil-version

--- a/neil
+++ b/neil
@@ -634,27 +634,6 @@ Examples:
              (not (:force opts)))
     (throw (ex-info "Requires clean working directory unless --force is provided" {}))))
 
-(def zero-version {:major 0 :minor 0 :patch 0})
-
-(defn strictly-increasing-semver-version? [prev-v next-v]
-  (let [prev-v' (or prev-v zero-version)]
-    (or (< (:major prev-v') (:major next-v))
-        (and (<= (:major prev-v') (:major next-v))
-             (< (:minor prev-v') (:minor next-v)))
-        (and (<= (:major prev-v') (:major next-v))
-             (<= (:minor prev-v') (:minor next-v))
-             (< (:patch prev-v') (:patch next-v))))))
-
-(defn assert-strictly-increasing-semver-version [prev-v next-v]
-  (when-not (strictly-increasing-semver-version? prev-v next-v)
-    (throw (ex-info "Versions in SemVer format must be strictly increasing"
-                    {:current-version (version-map->str prev-v :prefix true)
-                     :input-version (version-map->str next-v :prefix true)}))))
-
-(defn assert-valid-version-change [prev-v next-v]
-  (when (and (semver-version-map? prev-v) (semver-version-map? next-v))
-    (assert-strictly-increasing-semver-version prev-v next-v)))
-
 (defn run-set-command [{:keys [version dir deps-file] :as opts}]
   (let [deps-file' (proj/resolve-deps-file dir deps-file)
         opts' (assoc opts :deps-file deps-file')
@@ -662,13 +641,9 @@ Examples:
     (when git-tag-version-enabled
       (assert-clean-working-directory opts'))
     (proj/ensure-neil-project opts')
-    (let [deps-edn (some-> deps-file' slurp edn/read-string)
-          prev-version-string (deps-edn->project-version-string deps-edn)
-          prev-version-map (str->version-map prev-version-string)
-          next-version-map (str->version-map version)
+    (let [next-version-map (str->version-map version)
           next-version-string (version-map->str next-version-map :prefix false)
           next-prefixed-version (version-map->str next-version-map :prefix true)]
-      (assert-valid-version-change prev-version-map next-version-map)
       (set-version! next-version-string opts')
       (when git-tag-version-enabled
         (git/add ["deps.edn"] (git-opts opts'))

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -524,6 +524,10 @@ license
     {:cmds ["version" "tag"]
      :fn (partial neil-version/neil-version :tag)
      :aliases {:h :help}}
+    {:cmds ["version" "set"]
+     :fn (partial neil-version/neil-version :set)
+     :args->opts [:version]
+     :aliases {:h :help}}
     {:cmds ["version"]
      :fn neil-version/neil-version
      :aliases {:h :help}}

--- a/src/babashka/neil/git.clj
+++ b/src/babashka/neil/git.clj
@@ -91,6 +91,10 @@
   (sh "git add ." git-opts)
   (sh "git commit -m 'First commit'" git-opts))
 
+(defn list-tags [git-opts]
+  (let [{:keys [out]} (sh "git tag" git-opts)]
+    (str/split-lines (str/trim out))))
+
 (defn tag-contents [tag git-opts]
   (let [cmd ["git" "for-each-ref" (str "refs/tags/" tag)
              "--format" "%(contents)"]

--- a/test/babashka/neil/test_util.clj
+++ b/test/babashka/neil/test_util.clj
@@ -16,6 +16,9 @@
     (-> fs/parent (fs/create-dirs))
     (fs/delete-on-exit)))
 
+(defn read-deps-edn []
+  (edn/read-string (slurp (test-file "deps.edn"))))
+
 (defn set-deps-edn! [x]
   (spit (test-file "deps.edn") (pr-str x)))
 

--- a/test/babashka/neil/version_test.clj
+++ b/test/babashka/neil/version_test.clj
@@ -84,11 +84,7 @@
   (reset-test-dir)
   (set-deps-edn! {:aliases {:neil {:project {:version "1.0.0-alpha2"}}}})
   (git/ensure-repo git-opts)
-  (testing "Assert strictly increasing SemVer versions"
-    (let [v "1.0.0"]
-      (is (thrown-with-msg? ExceptionInfo #"Versions in SemVer format must be strictly increasing"
-                            (neil ["version" "set" v] :out :string)))))
-  (testing "Update deps.edn file with strictly increasing SemVer version"
+  (testing "Update deps.edn file with SemVer version"
     (let [v "2022.8.1"
           {:keys [out]} (neil ["version" "set" v] :out :string)]
       (is (= v (read-version-string))

--- a/test/babashka/neil/version_test.clj
+++ b/test/babashka/neil/version_test.clj
@@ -117,7 +117,26 @@
       (is (= v (git/show git-opts))
           "Latest commit message is same as version")
       (is (= v (git/tag-contents v git-opts))
-          "Latest annotated tag message is same as version"))))
+          "Latest annotated tag message is same as version")))
+  (testing "No commit or tag when --no-tag is set"
+    (let [prev-v (read-version-string)]
+      (doseq [args [["--no-tag"]
+                    ["--no-git-tag-version"]
+                    ["--tag" "false"]
+                    ["--git-tag-version" "false"]]]
+        (set-deps-edn! {:aliases {:neil {:project {:version prev-v}}}})
+        (let [prev-commit-count (git/commit-count git-opts)
+              prev-tag-count (count (git/list-tags git-opts))
+              next-v "2021a4"
+              {:keys [out]} (neil (concat ["version" "set" next-v] args) :out :string)]
+          (is (= next-v (read-version-string))
+              "Version is updated in deps.edn")
+          (is (= next-v out)
+              "Version is printed as output")
+          (is (= prev-commit-count (git/commit-count git-opts))
+              "No commit created")
+          (is (= prev-tag-count (count (git/list-tags git-opts)))
+              "No tag created"))))))
 
 (comment
   (clojure.test/run-tests))

--- a/test/babashka/neil/version_test.clj
+++ b/test/babashka/neil/version_test.clj
@@ -119,15 +119,15 @@
       (is (= v (git/tag-contents v git-opts))
           "Latest annotated tag message is same as version")))
   (testing "No commit or tag when --no-tag is set"
-    (let [prev-v (read-version-string)]
+    (let [prev-v (read-version-string)
+          prev-commit-count (git/commit-count git-opts)
+          prev-tag-count (count (git/list-tags git-opts))]
       (doseq [args [["--no-tag"]
                     ["--no-git-tag-version"]
                     ["--tag" "false"]
                     ["--git-tag-version" "false"]]]
         (set-deps-edn! {:aliases {:neil {:project {:version prev-v}}}})
-        (let [prev-commit-count (git/commit-count git-opts)
-              prev-tag-count (count (git/list-tags git-opts))
-              next-v "2021a4"
+        (let [next-v "2021a4"
               {:keys [out]} (neil (concat ["version" "set" next-v] args) :out :string)]
           (is (= next-v (read-version-string))
               "Version is updated in deps.edn")


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
  - https://github.com/babashka/neil/issues/81
- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/neil/blob/main/CHANGELOG.md) file with a description of the addressed issue.

## Overview

```
$ neil version set 1.0.0
v1.0.0

$ neil version set 1.0.0
----- Error --------------------------------------------------------------------
Type:     clojure.lang.ExceptionInfo
Message:  fatal: tag 'v1.0.0' already exists

$ neil version set 0.0.1
v0.0.1

$ neil version set 2022.8.1
v2022.8.1

$ neil version set 2021a3
2021a3

$ neil version set 2021a4 --no-tag
2021a4

$ git log --oneline
e6c729b (HEAD -> main, tag: 2021a3) 2021a3
b488e59 (tag: v2022.8.1) v2022.8.1
ca91832 (tag: v0.0.1) v0.0.1
7a0df02 (tag: v1.0.0) v1.0.0
9d55076 First commit

$ git tag
2021a3
v0.0.1
v1.0.0
v2022.8.1
```