### PR TITLE
Compatibility with `bbin`

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -1,6 +1,7 @@
 {:paths ["src" "dev" "test"]
  :pods {org.babashka/fswatcher {:version "0.0.3"}}
  :deps {org.babashka/neil {:local/root "."}}
+ :bbin/bin {neil {:main-opts ["-f" "neil"]}}
  :tasks {:requires ([babashka.fs :as fs]
                     [clojure.string :as str]
                     [selmer.parser :as p]


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/neil/blob/main/CHANGELOG.md) file with a description of the addressed issue.

## Overview

We only need this one small change to make `neil` available via a short [`bbin`](https://github.com/rads/bbin) command. It seems harmless to add this namespaced key for now even if the data structure is subject to change:

```
bbin install io.github.babashka/neil
```

I know we've been using `org.babashka/neil` up to this point, but I think it's more convenient to use the `io.github` name for installation since it supports inference of the `:git/*` coordinates. That said, it's still possible to use the `org.babashka` lib name using a longer command:

```
bbin install org.babashka/neil --git/url https://github.com/babashka/neil
```

## Testing

```
bbin install io.github.babashka/neil \
  --git/url https://github.com/rads/neil \
  --git/sha ad4c47117798ab09c1fc540d4eb4647194bc369c
```

## Changes

- **Add `:bbin/bin` key to `bb.edn`**
  - Without this key, the command `bbin install io.github.babashka/neil` does not work without an explicit `--main-opts` override on the user's side
  - The default `:main-opts` from `bbin` would be `["-m" "babashka.neil"]`, but we need to use the generated script for now to match existing packages and ensure `neil --version` is still working
  - If we stop using the generated script for `neil` and use the main function directly, the `:bbin/bin` key can be removed