### PR TITLE
Move `bump-version` before `tests` in `bb publish`

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -46,8 +46,8 @@
                   :doc "Bumps version, pushes tag"
                   :task
                   (do
-                    (run 'tests)
                     (run 'bump-version)
+                    (run 'tests)
                     (run 'update-readme)
                     (shell "git add .")
                     (let [version (-> (slurp "deps.edn") edn/read-string


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/neil/blob/main/CHANGELOG.md) file with a description of the addressed issue.

## Overview

I noticed that `neil version` was still returning `0.1.43`. This is because `tests` is what triggers the `gen-script` call, so the `bump-version` has to come before for the `deps.edn` changes to get picked up in the `neil` script.