### PR TITLE
`neil version`: Add bump subcommands

### DIFF
--- a/neil
+++ b/neil
@@ -651,6 +651,39 @@ Examples:
         (git/tag next-prefixed-version (git-opts opts')))
       (println next-prefixed-version))))
 
+(defn- assert-semver-version [version-map]
+  (when-not (semver-version-map? version-map)
+    (let [provided-version (version-map->str version-map :prefix false)]
+      (throw (ex-info "Only SemVer-style version strings can be bumped"
+                      {:provided-version provided-version})))))
+
+(defn- initial-version-map [semver-key override]
+  (assoc {:major 0 :minor 0 :patch 0} semver-key (or override 1)))
+
+(defn- bump-version [version-map semver-key override]
+  (if (not-set-version-map? version-map)
+    (initial-version-map semver-key override)
+    (do
+      (assert-semver-version version-map)
+      (let [next-version (or override (inc (get version-map semver-key)))
+            version-map' (assoc version-map semver-key next-version)
+            {:keys [major minor patch]} version-map']
+        (case semver-key
+          :major {:major major :minor 0 :patch 0}
+          :minor {:major major :minor minor :patch 0}
+          :patch {:major major :minor minor :patch patch})))))
+
+(defn run-bump-command [command {:keys [dir deps-file] :as opts}]
+  (let [deps-file (proj/resolve-deps-file dir deps-file)
+        deps-edn (some-> deps-file slurp edn/read-string)
+        project-version-string (deps-edn->project-version-string deps-edn)
+        _ (assert-valid-project-version-string project-version-string deps-file)
+        project-version-map (str->version-map project-version-string)
+        override (:version opts)
+        bumped-version-map (bump-version project-version-map command override)
+        bumped-version-str (version-map->str bumped-version-map :prefix false)]
+    (run-set-command (assoc opts :version bumped-version-str))))
+
 (defn print-help []
   (println (str/trim "
 Usage: neil version [set|major|minor|patch] [version]
@@ -669,7 +702,8 @@ Bump the :version key in the project config.")))
      (case command
        :root (run-root-command opts)
        :tag (run-tag-command opts)
-       :set (run-set-command opts)))))
+       :set (run-set-command opts)
+       (:major :minor :patch) (run-bump-command command opts)))))
 
 (ns babashka.neil
   {:no-doc true}
@@ -1199,6 +1233,18 @@ license
      :aliases {:h :help}}
     {:cmds ["version" "set"]
      :fn (partial neil-version/neil-version :set)
+     :args->opts [:version]
+     :aliases {:h :help}}
+    {:cmds ["version" "major"]
+     :fn (partial neil-version/neil-version :major)
+     :args->opts [:version]
+     :aliases {:h :help}}
+    {:cmds ["version" "minor"]
+     :fn (partial neil-version/neil-version :minor)
+     :args->opts [:version]
+     :aliases {:h :help}}
+    {:cmds ["version" "patch"]
+     :fn (partial neil-version/neil-version :patch)
      :args->opts [:version]
      :aliases {:h :help}}
     {:cmds ["version"]

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -528,6 +528,18 @@ license
      :fn (partial neil-version/neil-version :set)
      :args->opts [:version]
      :aliases {:h :help}}
+    {:cmds ["version" "major"]
+     :fn (partial neil-version/neil-version :major)
+     :args->opts [:version]
+     :aliases {:h :help}}
+    {:cmds ["version" "minor"]
+     :fn (partial neil-version/neil-version :minor)
+     :args->opts [:version]
+     :aliases {:h :help}}
+    {:cmds ["version" "patch"]
+     :fn (partial neil-version/neil-version :patch)
+     :args->opts [:version]
+     :aliases {:h :help}}
     {:cmds ["version"]
      :fn neil-version/neil-version
      :aliases {:h :help}}


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
  - https://github.com/babashka/neil/issues/81
- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/neil/blob/main/CHANGELOG.md) file with a description of the addressed issue.

## Overview

```
$ cat deps.edn
{:paths ["src"]
 :deps  {}
 :aliases
  {:neil {:project {:name foo/foo}}}}

$ neil version
{:neil "0.1.45", :project :version-not-set}

$ neil version minor
v0.1.0

$ neil version patch
v0.1.1

$ neil version minor 3
v0.3.0

$ neil version major
v1.0.0
```