### PR TITLE
`neil version`: Fix missing pre-release and build in version strings

### DIFF
--- a/neil
+++ b/neil
@@ -530,17 +530,18 @@ Examples:
                (when pre-release {:pre-release pre-release})
                (when build {:build build}))))))
 
-(defn- str->version-map [s]
+(defn str->version-map [s]
   (cond
     (#{:version-not-set} s) {:version-not-set true}
     (string? s) (or (parse-semver-string s) {:raw-string s})
     :else (throw (ex-info "Invalid version string" {:version-string s}))))
 
-(defn- semver-version-map->str [version-map str-opts]
-  (let [{:keys [minor major patch qualifier]} version-map]
+(defn semver-version-map->str [version-map str-opts]
+  (let [{:keys [minor major patch pre-release build]} version-map]
     (str (when (:prefix str-opts) "v")
          (str/join "." [major minor patch])
-         (when qualifier (str "-" qualifier)))))
+         (when pre-release (str "-" pre-release))
+         (when build (str "+" build)))))
 
 (defn version-map->str [version-map & {:as str-opts}]
   (cond

--- a/src/babashka/neil/version.clj
+++ b/src/babashka/neil/version.clj
@@ -38,17 +38,18 @@
                (when pre-release {:pre-release pre-release})
                (when build {:build build}))))))
 
-(defn- str->version-map [s]
+(defn str->version-map [s]
   (cond
     (#{:version-not-set} s) {:version-not-set true}
     (string? s) (or (parse-semver-string s) {:raw-string s})
     :else (throw (ex-info "Invalid version string" {:version-string s}))))
 
-(defn- semver-version-map->str [version-map str-opts]
-  (let [{:keys [minor major patch qualifier]} version-map]
+(defn semver-version-map->str [version-map str-opts]
+  (let [{:keys [minor major patch pre-release build]} version-map]
     (str (when (:prefix str-opts) "v")
          (str/join "." [major minor patch])
-         (when qualifier (str "-" qualifier)))))
+         (when pre-release (str "-" pre-release))
+         (when build (str "+" build)))))
 
 (defn version-map->str [version-map & {:as str-opts}]
   (cond

--- a/test/babashka/neil/version_test.clj
+++ b/test/babashka/neil/version_test.clj
@@ -170,5 +170,10 @@
   (let [{:keys [out]} (neil "version" :out :edn)]
     (is (= "1.0.0" (:project out)))))
 
+(deftest version-map->str-test
+  (doseq [v ["0.0.10-dev" "0.0.10+build" "0.0.10-dev+build"]]
+    (let [version-map (version/str->version-map v)]
+      (is (= v (version/version-map->str version-map))))))
+
 (comment
   (clojure.test/run-tests))


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
  - https://github.com/babashka/neil/issues/81
- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/neil/blob/main/CHANGELOG.md) file with a description of the addressed issue.

## Overview

Fixes the following issue:

```
$ neil version set 0.0.10-dev
v0.0.10
```