### PR TITLE
upgrade alias extra-deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Extend `neil dep upgrade` to upgrade alias deps (now the default).
+  - `neil dep upgrade --alias tests` supports upgrading deps for a particular alias.
+  - `neil dep upgrade --no-aliases` supports upgrading _only_ the project deps.
+
 ## 0.1.46 (2022-10-12)
 
 - Introduce `neil dep upgrade` API for upgrading existing dependencies. By [@teodorlu](https://github.com/teodorlu) and [@russmatney](https://github.com/russmatney).

--- a/neil
+++ b/neil
@@ -1209,10 +1209,12 @@ will return libraries with 'test framework' in their description.")))
                                (latest-mvn-version lib))]
           {:mvn/version version})))
 
-(defn opts->all-deps
+(defn opts->specified-deps
   "Returns all :deps and :alias :extra-deps for the deps.edn indicated by `opts`."
   [opts]
-  (let [no-aliases?            (:no-aliases opts)
+  (let [lib                    (some-> opts :lib symbol)
+        alias                  (some-> opts :alias)
+        no-aliases?            (:no-aliases opts)
         {:keys [deps aliases]} (-> (edn-string opts) edn/read-string)
         current-deps
         (->> deps (map (fn [[lib current]]
@@ -1225,7 +1227,9 @@ will return libraries with 'test framework' in their description.")))
                                                {:alias   alias
                                                 :lib     lib
                                                 :current current})))))))]
-    (concat current-deps alias-deps)))
+    (->> (concat current-deps alias-deps)
+         (filter (fn [dep] (if alias (= alias (:alias dep)) true)))
+         (filter (fn [dep] (if lib (= lib (:lib dep)) true))))))
 
 (defn do-dep-upgrade
   "Updates the deps version in deps.edn for a single lib,
@@ -1254,10 +1258,7 @@ will return libraries with 'test framework' in their description.")))
 (defn dep-upgrade [{:keys [opts]}]
   (let [lib           (some-> opts :lib symbol)
         alias         (some-> opts :alias)
-        all-deps      (opts->all-deps opts)
-        deps-to-check (->> all-deps
-                           (filter (fn [dep] (if alias (= alias (:alias dep)) true)))
-                           (filter (fn [dep] (if lib (= lib (:lib dep)) true))))
+        deps-to-check (opts->specified-deps opts)
         upgrades      (->> deps-to-check
                            (pmap (fn [dep] (merge dep {:latest (dep->latest dep)})))
                            ;; keep if :latest version was found

--- a/neil
+++ b/neil
@@ -1188,78 +1188,92 @@ will return libraries with 'test framework' in their description.")))
                  :description (pr-str (:description search-result)))))))
 
 
-(defn lib+current->latest
-  "Expects a lib symbol like `'babashka/fs` and a dep description
-  like `{:mvn/version \"some-version\"}` or `{:git/sha \"sha-blah\"}`.
+(defn dep->latest
+  "Expects a `dep-upgrade` map, with `:lib` and `:current` keys.
+  `:current` is the dep's current coordinates, like `{:mvn/version \"some-version\"}`
+  or `{:git/sha \"sha-blah\"}`.
 
-  Returns a dep description of the same form (a map with `:mvn/version` or `:git/sha`)
-  with the latest version or latest sha."
-  [lib current-dep]
-  (cond (:git/sha current-dep)
+  Returns a `latest` coordinate as a map with `:mvn/version` or `:git/sha`.
+  Note that this is not a full dep coordinate - we rely on `dep-add` later to include
+  `:git/url`, for example."
+  [{:keys [current lib] :as _dep-update}]
+  (cond (:git/sha current)
         (when-let [sha (git/latest-github-sha lib)]
           {:git/sha sha})
 
-        (:mvn/version current-dep)
+        (:mvn/version current)
         (when-let [version (or (latest-clojars-version lib)
                                (latest-mvn-version lib))]
           {:mvn/version version})))
 
-(defn do-dep-upgrade
-  "Updates the deps version in deps.edn for a single lib with the version passed in `latest`.
-  First compares `current` and `latest`.
-  Supports `:dry-run` in the passed `opts`."
-  [opts lib current {:keys [git/sha mvn/version] :as _latest}]
-  (when (or (and sha (not= (:git/sha current) sha))
-            (and version (not= (:mvn/version current) version)))
-    (if (:dry-run opts)
-      (if sha
-        (println "Would upgrade" :lib lib :version (:git/sha current) :latest-sha sha)
-        (println "Would upgrade" :lib lib :version (:mvn/version current) :latest-version version))
-      (do
-        (if sha
-          (println "Upgrading" :lib lib :version (:git/sha current) :latest-sha sha)
-          (println "Upgrading" :lib lib :version (:mvn/version current) :latest-version version))
-        (dep-add {:opts (cond-> opts
-                          lib     (assoc :lib lib)
-                          version (assoc :version version)
-                          sha     (assoc :sha sha))})))))
+(defn opts->all-deps
+  "Returns all :deps and :alias :extra-deps for the deps.edn indicated by `opts`."
+  [opts]
+  (let [{:keys [deps aliases]} (-> (edn-string opts) edn/read-string)
+        current-deps
+        (->> deps (map (fn [[lib current]]
+                         {:lib lib :current current})))
+        alias-deps
+        (->> aliases (mapcat (fn [[alias def]]
+                               (->> (:extra-deps def)
+                                    (map (fn [[lib current]]
+                                           {:alias   alias
+                                            :lib     lib
+                                            :current current}))))))]
+    (concat current-deps alias-deps)))
 
-(defn dep-upgrade [{:keys [opts] :as _all}]
-  (if (:lib opts)
-    ;; upgrade a single dependency
-    (let [lib     (:lib opts)
-          lib     (symbol lib)
-          current (-> (edn-string opts)
-                      edn/read-string
-                      :deps
-                      (get lib))
-          latest  (when current (lib+current->latest lib current))]
-      (cond (not current)
+(defn do-dep-upgrade
+  "Updates the deps version in deps.edn for a single lib,
+  as described in `dep-upgrade`, which is a map with
+  `:lib`, `:current`, `:latest` (the current and latest dep coords), and optionally `:alias`.
+
+  When `:current` and `:latest` do not match, `:latest` is written to deps.edn via `dep-add`.
+  Supports `:dry-run` in the passed `opts` to instead just print the update."
+  [opts {:keys [lib current latest alias] :as _dep-upgrade}]
+  (let [{:keys [git/sha mvn/version]} latest
+        log-args
+        (concat (when alias [:alias alias]) [:lib lib] [:version current]
+                (when sha [:latest-sha sha]) (when version [:latest-version version]))
+        log-msg                       (fn [msg] (apply println msg log-args))]
+    (when (or (and sha (not= (:git/sha current) sha))
+              (and version (not= (:mvn/version current) version)))
+      (if (:dry-run opts)
+        (log-msg "Would upgrade")
+        (do (log-msg "Upgrading")
+            (dep-add {:opts (cond-> opts
+                              lib     (assoc :lib lib)
+                              alias   (assoc :alias alias)
+                              version (assoc :version version)
+                              sha     (assoc :sha sha))}))))))
+
+(defn dep-upgrade [{:keys [opts]}]
+  (let [lib           (some-> opts :lib symbol)
+        alias         (some-> opts :alias)
+        all-deps      (opts->all-deps opts)
+        deps-to-check (->> all-deps
+                           (filter (fn [dep] (if alias (= alias (:alias dep)) true)))
+                           (filter (fn [dep] (if lib (= lib (:lib dep)) true))))
+        upgrades      (->> deps-to-check
+                           (pmap (fn [dep] (merge dep {:latest (dep->latest dep)})))
+                           ;; keep if :latest version was found
+                           (filter (fn [dep] (some? (:latest dep)))))]
+    (when lib
+      ;; logging and early-exit when :lib is specified
+      (cond (not (seq deps-to-check))
             (binding [*out* *err*]
-              (println "Local dependency not found:" lib)
+              (if alias
+                (println "Local dependency not found:" lib "for alias:" alias)
+                (println "Local dependency not found:" lib))
               (println "Use `neil dep add` to add dependencies.")
               (System/exit 1))
 
-            (and (not (:git/sha latest)) (not (:mvn/version latest)))
+            (not (seq upgrades))
             (binding [*out* *err*]
+              ;; note this could also mean we've hit github's rate limit
               (println "No remote version found for" lib)
-              (System/exit 1))
+              (System/exit 1))))
 
-            :else (do-dep-upgrade opts lib current latest)))
-
-    ;; upgrade multiple dependencies
-    (let [current-deps (-> (edn-string opts)
-                           edn/read-string
-                           :deps)
-          latest-deps  (->> current-deps
-                            (pmap (fn [[lib current]]
-                                    [lib (lib+current->latest lib current)]))
-                            (filter (fn [[_lib new-version]]
-                                      (some? new-version)))
-                            (into {}))]
-      (doseq [[lib current] current-deps]
-        (let [latest (get latest-deps lib)]
-          (do-dep-upgrade opts lib current latest))))))
+    (doseq [dep-upgrade upgrades] (do-dep-upgrade opts dep-upgrade))))
 
 
 (defn print-help [_]

--- a/neil
+++ b/neil
@@ -796,7 +796,10 @@ using the [major|minor|patch] subcommands.
                        :desc "Add to <file> instead of deps.edn."
                        :default "deps.edn"}
            :limit {:coerce :long}
-           :dry-run {:coerce :boolean}})
+           :dry-run {:coerce :boolean
+                     :desc "dep upgrade only. Prevents updates to deps.edn."}
+           :no-aliases {:coerce :boolean
+                        :desc "Prevents updates to alias :extra-deps when upgrading."}})
 
 (def windows? (fs/windows?))
 
@@ -1209,17 +1212,19 @@ will return libraries with 'test framework' in their description.")))
 (defn opts->all-deps
   "Returns all :deps and :alias :extra-deps for the deps.edn indicated by `opts`."
   [opts]
-  (let [{:keys [deps aliases]} (-> (edn-string opts) edn/read-string)
+  (let [no-aliases?            (:no-aliases opts)
+        {:keys [deps aliases]} (-> (edn-string opts) edn/read-string)
         current-deps
         (->> deps (map (fn [[lib current]]
                          {:lib lib :current current})))
         alias-deps
-        (->> aliases (mapcat (fn [[alias def]]
-                               (->> (:extra-deps def)
-                                    (map (fn [[lib current]]
-                                           {:alias   alias
-                                            :lib     lib
-                                            :current current}))))))]
+        (if no-aliases? []
+            (->> aliases (mapcat (fn [[alias def]]
+                                   (->> (:extra-deps def)
+                                        (map (fn [[lib current]]
+                                               {:alias   alias
+                                                :lib     lib
+                                                :current current})))))))]
     (concat current-deps alias-deps)))
 
 (defn do-dep-upgrade
@@ -1300,12 +1305,18 @@ dep
   search: Search Clojars for a string in any attribute of an artifact
     Run `neil dep search --help` to see all options.
 
-  upgrade: Upgrade all libs in the deps.edn file.
+  upgrade: Upgrade libs in the deps.edn file.
     Supports --lib <libname> or :lib <libname> for upgrading a single, specified lib.
     Supports --dry-run for printing updates without updating the deps.edn file.
+    Supports --alias <some-alias> for limiting upgrades to an alias.
+      Note that all deps (including alias deps) are upgraded by default.
+    Supports --no-aliases if you'd like to upgrade only the project's :deps.
+
     Ex: `neil dep upgrade` - upgrade all deps.
     Ex: `neil dep upgrade --dry-run` - print deps that would be upgraded.
+    Ex: `neil dep upgrade --alias lint` - update only deps for the `lint` alias.
     Ex: `neil dep upgrade :lib clj-kondo/clj-kondo` - update a single dep.
+
   update: Alias for `upgrade`.
 
 license

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -532,12 +532,17 @@ dep
   search: Search Clojars for a string in any attribute of an artifact
     Run `neil dep search --help` to see all options.
 
-  upgrade: Upgrade all libs in the deps.edn file.
+  upgrade: Upgrade libs in the deps.edn file.
     Supports --lib <libname> or :lib <libname> for upgrading a single, specified lib.
     Supports --dry-run for printing updates without updating the deps.edn file.
+    Supports --alias <some-alias> for limiting upgrades to an alias.
+      Note that all deps (including alias deps) are upgraded by default.
+
     Ex: `neil dep upgrade` - upgrade all deps.
     Ex: `neil dep upgrade --dry-run` - print deps that would be upgraded.
+    Ex: `neil dep upgrade --alias lint` - update only deps for the `lint` alias.
     Ex: `neil dep upgrade :lib clj-kondo/clj-kondo` - update a single dep.
+
   update: Alias for `upgrade`.
 
 license


### PR DESCRIPTION
- [X] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

  Relevant issue: https://github.com/babashka/neil/issues/107

- [X] I have updated the [CHANGELOG.md](https://github.com/babashka/neil/blob/main/CHANGELOG.md) file with a description of the addressed issue.

As a follow-up to the new `neil dep upgrade` feature - this adds support for
upgrading deps in `:aliases -> :extra-deps`.

By default, alias deps are included in the basic `neil dep upgrade` usage. You
can specify an upgrade to _only_ an alias by including `--alias
<alias-to-upgrade>`. This can be combined with `--lib <lib-name>`, if you need
to specify a lib in a particular alias.

Alias upgrades can be ignored with a new `--no-aliases` flag, if you
want to upgrade just your `:deps`.

If the same lib is specified in two aliases, in one case as a :git/sha, the
other as a :mvn/version, each dep maintains the same coordinate type, fetching
the latest for each.

Let me know if we prefer different defaults, behavior, or flag names!

---

I hit the github rate limit fairly quickly working on this - it looks like it's
only 60 unauthenticated requests per hour, and I ended up using the just-added
env vars and a personal access token to work around it. It might be worth
refactoring some of the tests I added in the last PR to reduce the number of
calls, or otherwise mocking the github/curl hits.