### PR TITLE
readme: contrib section mentions the rate limit + workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,13 @@ Load it using your preferred Emacs package manager, e.g., for Doom Emacs:
 If this project shows potential to you, I'd be happy to discuss and receive
 contributions.
 
+#### Github's Rate Limit
+
+Developing and running tests locally, you may run into github's rate limit (60 unauthenticated hits per hour). The current workaround for this is creating a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) and setting two env vars:
+
+- `BABASHKA_NEIL_DEV_GITHUB_USER`
+- `BABASHKA_NEIL_DEV_GITHUB_TOKEN`
+
 ## Dev
 
 See


### PR DESCRIPTION
Adds a quick blurb to the readme to head off new neil devs running into arbitrarily failing tests.

We could also move to handling the 403 that comes back, maybe logging that a 403 was hit (not a 404 or 'remote not found', as is the current behavior). But, it doesn't seem like anyone has this problem right now, so no need to create extra work.

-------

- [X] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
    - Related issue: https://github.com/babashka/neil/issues/111