### PR TITLE
dep add `:tag` and `:latest-tag`, upgrade respecting `:tag` and `:git/tag`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,16 @@
 - `neil dep add` now supports `--tag` and `--latest-tag`
 - `neil dep upgrade`
   - when `:git/tag` is used, upgrades to the repo's latest tag (instead of the latest sha)
-  - support `:tag` and `:sha`, which tools.deps supports (for backwards compatibility)
+  - support prefixless `:tag` and `:sha` coords, which tools.deps supports (for backwards compatibility)
   - upgrade alias deps (now the default).
     - `neil dep upgrade --alias tests` supports upgrading deps for a particular alias.
     - `neil dep upgrade --no-aliases` supports upgrading _only_ the project deps.
+  - the `neil dep upgrade --dry-run` output can now be piped back into `neil dep
+    add`, so you can now select a single upgrade from a list of available via `fzf`:
+
+```
+neil dep upgrade --dry-run | fzf | xargs ./neil dep add
+```
 
 ## 0.1.46 (2022-10-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Extend `neil dep upgrade` to upgrade alias deps (now the default).
   - `neil dep upgrade --alias tests` supports upgrading deps for a particular alias.
   - `neil dep upgrade --no-aliases` supports upgrading _only_ the project deps.
+- `neil dep add` now supports `--tag` and `--latest-tag`
 
 ## 0.1.46 (2022-10-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## Unreleased
 
-- Extend `neil dep upgrade` to upgrade alias deps (now the default).
-  - `neil dep upgrade --alias tests` supports upgrading deps for a particular alias.
-  - `neil dep upgrade --no-aliases` supports upgrading _only_ the project deps.
 - `neil dep add` now supports `--tag` and `--latest-tag`
+- `neil dep upgrade`
+  - when `:git/tag` is used, upgrades to the repo's latest tag (instead of the latest sha)
+  - support `:tag` and `:sha`, which tools.deps supports (for backwards compatibility)
+  - upgrade alias deps (now the default).
+    - `neil dep upgrade --alias tests` supports upgrading deps for a particular alias.
+    - `neil dep upgrade --no-aliases` supports upgrading _only_ the project deps.
 
 ## 0.1.46 (2022-10-12)
 

--- a/neil
+++ b/neil
@@ -1279,17 +1279,18 @@ will return libraries with 'test framework' in their description.")))
   [opts {:keys [lib current latest alias] :as _dep-upgrade}]
   (let [{:keys [git/tag git/sha mvn/version]} latest
         log-args
-        (concat (when alias [:alias alias]) [:lib lib] [:version current]
-                (when tag [:latest-tag tag])
-                (when sha [:latest-sha sha])
-                (when version [:latest-version version]))
-        log-msg                       (fn [msg] (apply println msg log-args))]
+        (concat (when alias [:alias alias]) [:lib lib]
+                [:current-version ((some-fn :git/tag :git/sha :mvn/version) current)]
+                (when tag [:tag tag])
+                (when (and (not tag) sha) [:sha sha])
+                (when version [:version version]))
+        log-action (fn [action] (apply println :action (str "\"" action "\"") log-args))]
     (when (or (and tag (not= (:git/tag current) tag))
               (and sha (not= (:git/sha current) sha))
               (and version (not= (:mvn/version current) version)))
       (if (:dry-run opts)
-        (log-msg "Would upgrade")
-        (do (log-msg "Upgrading")
+        (log-action "upgrading (dry run)")
+        (do (log-action "upgrading")
             (dep-add {:opts (cond-> opts
                               lib     (assoc :lib lib)
                               alias   (assoc :alias alias)

--- a/neil
+++ b/neil
@@ -1200,7 +1200,7 @@ will return libraries with 'test framework' in their description.")))
   Note that this is not a full dep coordinate - we rely on `dep-add` later to include
   `:git/url`, for example."
   [{:keys [current lib] :as _dep-update}]
-  (cond (:git/sha current)
+  (cond (or (:git/sha current) (:sha current))
         (when-let [sha (git/latest-github-sha lib)]
           {:git/sha sha})
 

--- a/neil
+++ b/neil
@@ -786,6 +786,8 @@ using the [major|minor|patch] subcommands.
            :version {:desc "Optional. When not provided, picks newest version from Clojars or Maven Central."}
            :sha {:desc "When provided, assumes lib refers to Github repo."}
            :latest-sha {:desc "When provided, assumes lib refers to Github repo and then picks latest SHA from it."}
+           :tag {:desc "When provided, assumes lib refers to Github repo."}
+           :latest-tag {:desc "When provided, assumes lib refers to Github repo and then picks latest tag from it."}
            :deps/root {:desc "Sets deps/root to give value."}
            :as {:desc "Use as dependency name in deps.edn"
                 :coerce :symbol}
@@ -1070,7 +1072,20 @@ using the [major|minor|patch] subcommands.
   (println "Options:")
   (println (cli/format-opts
             {:spec spec
-             :order [:lib :version :sha :latest-sha :deps/root :as :alias :deps-file]})))
+             :order [:lib :version :sha :latest-sha :tag :latest-tag :deps/root :as :alias :deps-file]})))
+
+(comment
+  (git/list-github-tags 'clj-kondo/clj-kondo)
+  (git/list-github-tags 'clj-kondo/clj-kondo)
+  (git/latest-github-tag 'clj-kondo/clj-kondo)
+  {:name "v2022.10.14",
+   :zipball_url "https://api.github.com/repos/clj-kondo/clj-kondo/zipball/refs/tags/v2022.10.14",
+   :tarball_url "https://api.github.com/repos/clj-kondo/clj-kondo/tarball/refs/tags/v2022.10.14",
+   :commit
+   {:sha "a1f5f1b03c34d915015cde74431ddd6ad2cc17e9",
+    :url "https://api.github.com/repos/clj-kondo/clj-kondo/commits/a1f5f1b03c34d915015cde74431ddd6ad2cc17e9"},
+   :node_id "MDM6UmVmMTc2ODI5NzE0OnJlZnMvdGFncy92MjAyMi4xMC4xNA=="}
+  )
 
 (defn dep-add [{:keys [opts]}]
   (if (or (:help opts) (:h opts) (not (:lib opts)))
@@ -1082,22 +1097,29 @@ using the [major|minor|patch] subcommands.
             lib (:lib opts)
             lib (symbol lib)
             alias (:alias opts)
-            explicit-git? (or (:sha opts)
-                              (:latest-sha opts))
-            [version git?] (if explicit-git?
-                             [(or (:sha opts)
-                                  (git/latest-github-sha lib)) true]
-                             (or
-                              (when-let [v (:version opts)]
-                                [v false])
-                              (when-let [v (latest-clojars-version lib)]
-                                [v false])
-                              (when-let [v (latest-mvn-version lib)]
-                                [v false])
-                              (when-let [v (git/latest-github-sha lib)]
-                                [v true])))
-            mvn? (not git?)
-            git-url (when git?
+            explicit-git-sha? (or (:sha opts) (:latest-sha opts))
+            explicit-git-tag? (or (:tag opts) (:latest-tag opts))
+            [version coord-type?]
+            (cond explicit-git-tag?
+                  [(or (and (:tag opts)
+                            (git/find-github-tag lib (:tag opts)))
+                       (git/latest-github-tag lib)) :git/tag]
+                  explicit-git-sha?
+                  [(or (:sha opts) (git/latest-github-sha lib)) :git/sha]
+                  :else
+                  (or
+                    (when-let [v (:version opts)]
+                      [v :mvn])
+                    (when-let [v (latest-clojars-version lib)]
+                      [v :mvn])
+                    (when-let [v (latest-mvn-version lib)]
+                      [v :mvn])
+                    (when-let [v (git/latest-github-sha lib)]
+                      [v :git/sha])))
+            mvn? (= coord-type? :mvn)
+            git-sha? (= coord-type? :git/sha)
+            git-tag? (= coord-type? :git/tag)
+            git-url (when (or git-sha? git-tag?)
                       (or (:git/url opts)
                           (str "https://github.com/" (git/clean-github-lib lib))))
             as (or (:as opts) lib)
@@ -1122,16 +1144,26 @@ using the [major|minor|patch] subcommands.
                     mvn?
                     (r/assoc-in edn-nodes path
                                 {:mvn/version version})
-                    git?
+                    git-sha?
                     ;; multiple steps to force newlines
                     (-> edn-nodes
-                        (r/assoc-in
-                         (conj path :git/url) git-url)
+                        (r/assoc-in (conj path :git/url) git-url)
                         str
                         r/parse-string
-                        (r/assoc-in
-                         (conj path :git/sha) version)))
-            nodes (if-let [root (and git? (:deps/root opts))]
+                        (r/assoc-in (conj path :git/sha) version))
+
+                    git-tag?
+                    ;; multiple steps to force newlines
+                    (-> edn-nodes
+                        (r/assoc-in (conj path :git/url) git-url)
+                        str
+                        r/parse-string
+                        (r/assoc-in (conj path :git/tag) (-> version :name))
+                        str
+                        r/parse-string
+                        (r/assoc-in (conj path :git/sha)
+                                    (some-> version :commit :sha (subs 0 7)))))
+            nodes (if-let [root (and (or git-sha? git-tag?) (:deps/root opts))]
                     (-> nodes
                         (r/assoc-in (conj path :deps/root) root))
                     nodes)

--- a/neil
+++ b/neil
@@ -1232,14 +1232,20 @@ will return libraries with 'test framework' in their description.")))
   Note that this is not a full dep coordinate - we rely on `dep-add` later to include
   `:git/url`, for example."
   [{:keys [current lib] :as _dep-update}]
-  (cond (or (:git/sha current) (:sha current))
-        (when-let [sha (git/latest-github-sha lib)]
-          {:git/sha sha})
+  (cond
+    (or (:git/tag current) (:tag current))
+    (when-let [tag (git/latest-github-tag lib)]
+      {:git/tag (:name tag)
+       :git/sha (-> tag :commit :sha (subs 0 7))})
 
-        (:mvn/version current)
-        (when-let [version (or (latest-clojars-version lib)
-                               (latest-mvn-version lib))]
-          {:mvn/version version})))
+    (or (:git/sha current) (:sha current))
+    (when-let [sha (git/latest-github-sha lib)]
+      {:git/sha sha})
+
+    (:mvn/version current)
+    (when-let [version (or (latest-clojars-version lib)
+                           (latest-mvn-version lib))]
+      {:mvn/version version})))
 
 (defn opts->specified-deps
   "Returns all :deps and :alias :extra-deps for the deps.edn indicated by `opts`."
@@ -1271,12 +1277,15 @@ will return libraries with 'test framework' in their description.")))
   When `:current` and `:latest` do not match, `:latest` is written to deps.edn via `dep-add`.
   Supports `:dry-run` in the passed `opts` to instead just print the update."
   [opts {:keys [lib current latest alias] :as _dep-upgrade}]
-  (let [{:keys [git/sha mvn/version]} latest
+  (let [{:keys [git/tag git/sha mvn/version]} latest
         log-args
         (concat (when alias [:alias alias]) [:lib lib] [:version current]
-                (when sha [:latest-sha sha]) (when version [:latest-version version]))
+                (when tag [:latest-tag tag])
+                (when sha [:latest-sha sha])
+                (when version [:latest-version version]))
         log-msg                       (fn [msg] (apply println msg log-args))]
-    (when (or (and sha (not= (:git/sha current) sha))
+    (when (or (and tag (not= (:git/tag current) tag))
+              (and sha (not= (:git/sha current) sha))
               (and version (not= (:mvn/version current) version)))
       (if (:dry-run opts)
         (log-msg "Would upgrade")
@@ -1285,7 +1294,8 @@ will return libraries with 'test framework' in their description.")))
                               lib     (assoc :lib lib)
                               alias   (assoc :alias alias)
                               version (assoc :version version)
-                              sha     (assoc :sha sha))}))))))
+                              tag     (assoc :tag tag)
+                              (and (not tag) sha) (assoc :sha sha))}))))))
 
 (defn dep-upgrade [{:keys [opts]}]
   (let [lib           (some-> opts :lib symbol)

--- a/neil
+++ b/neil
@@ -1074,19 +1074,6 @@ using the [major|minor|patch] subcommands.
             {:spec spec
              :order [:lib :version :sha :latest-sha :tag :latest-tag :deps/root :as :alias :deps-file]})))
 
-(comment
-  (git/list-github-tags 'clj-kondo/clj-kondo)
-  (git/list-github-tags 'clj-kondo/clj-kondo)
-  (git/latest-github-tag 'clj-kondo/clj-kondo)
-  {:name "v2022.10.14",
-   :zipball_url "https://api.github.com/repos/clj-kondo/clj-kondo/zipball/refs/tags/v2022.10.14",
-   :tarball_url "https://api.github.com/repos/clj-kondo/clj-kondo/tarball/refs/tags/v2022.10.14",
-   :commit
-   {:sha "a1f5f1b03c34d915015cde74431ddd6ad2cc17e9",
-    :url "https://api.github.com/repos/clj-kondo/clj-kondo/commits/a1f5f1b03c34d915015cde74431ddd6ad2cc17e9"},
-   :node_id "MDM6UmVmMTc2ODI5NzE0OnJlZnMvdGFncy92MjAyMi4xMC4xNA=="}
-  )
-
 (defn dep-add [{:keys [opts]}]
   (if (or (:help opts) (:h opts) (not (:lib opts)))
     (print-dep-add-help)

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -511,17 +511,18 @@ will return libraries with 'test framework' in their description.")))
   [opts {:keys [lib current latest alias] :as _dep-upgrade}]
   (let [{:keys [git/tag git/sha mvn/version]} latest
         log-args
-        (concat (when alias [:alias alias]) [:lib lib] [:version current]
-                (when tag [:latest-tag tag])
-                (when sha [:latest-sha sha])
-                (when version [:latest-version version]))
-        log-msg                       (fn [msg] (apply println msg log-args))]
+        (concat (when alias [:alias alias]) [:lib lib]
+                [:current-version ((some-fn :git/tag :git/sha :mvn/version) current)]
+                (when tag [:tag tag])
+                (when (and (not tag) sha) [:sha sha])
+                (when version [:version version]))
+        log-action (fn [action] (apply println :action (str "\"" action "\"") log-args))]
     (when (or (and tag (not= (:git/tag current) tag))
               (and sha (not= (:git/sha current) sha))
               (and version (not= (:mvn/version current) version)))
       (if (:dry-run opts)
-        (log-msg "Would upgrade")
-        (do (log-msg "Upgrading")
+        (log-action "upgrading (dry run)")
+        (do (log-action "upgrading")
             (dep-add {:opts (cond-> opts
                               lib     (assoc :lib lib)
                               alias   (assoc :alias alias)

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -432,7 +432,7 @@ will return libraries with 'test framework' in their description.")))
   Note that this is not a full dep coordinate - we rely on `dep-add` later to include
   `:git/url`, for example."
   [{:keys [current lib] :as _dep-update}]
-  (cond (:git/sha current)
+  (cond (or (:git/sha current) (:sha current))
         (when-let [sha (git/latest-github-sha lib)]
           {:git/sha sha})
 

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -306,19 +306,6 @@
             {:spec spec
              :order [:lib :version :sha :latest-sha :tag :latest-tag :deps/root :as :alias :deps-file]})))
 
-(comment
-  (git/list-github-tags 'clj-kondo/clj-kondo)
-  (git/list-github-tags 'clj-kondo/clj-kondo)
-  (git/latest-github-tag 'clj-kondo/clj-kondo)
-  {:name "v2022.10.14",
-   :zipball_url "https://api.github.com/repos/clj-kondo/clj-kondo/zipball/refs/tags/v2022.10.14",
-   :tarball_url "https://api.github.com/repos/clj-kondo/clj-kondo/tarball/refs/tags/v2022.10.14",
-   :commit
-   {:sha "a1f5f1b03c34d915015cde74431ddd6ad2cc17e9",
-    :url "https://api.github.com/repos/clj-kondo/clj-kondo/commits/a1f5f1b03c34d915015cde74431ddd6ad2cc17e9"},
-   :node_id "MDM6UmVmMTc2ODI5NzE0OnJlZnMvdGFncy92MjAyMi4xMC4xNA=="}
-  )
-
 (defn dep-add [{:keys [opts]}]
   (if (or (:help opts) (:h opts) (not (:lib opts)))
     (print-dep-add-help)

--- a/test/babashka/neil/dep_upgrade_test.clj
+++ b/test/babashka/neil/dep_upgrade_test.clj
@@ -79,6 +79,21 @@
         ;; should be a different sha
         (is (not (= sha (:git/sha clj-kondo-original)))))))
 
+  (testing "upgrading a coordinate with just :sha (not :git/sha) should still work"
+    (spit test-file-path "{:deps {clj-kondo/clj-kondo
+                            {:git/url \"https://github.com/clj-kondo/clj-kondo\"
+                             :sha \"6ffc3934cb83d2c4fff16d84198c73b40cd8a078\"}}}")
+    (let [original (get-dep-version 'clj-kondo/clj-kondo)]
+      ;; here we upgrade and then assert that the sha is different,
+      ;; and on :git/sha rather than :sha
+      (is (:sha original))
+      (test-util/neil "dep upgrade" :deps-file test-file-path)
+      (let [upgraded (get-dep-version 'clj-kondo/clj-kondo)]
+        (is (:git/sha upgraded))
+        (is (not (:sha upgraded)))
+        ;; should be a different sha
+        (is (not (= (:git/sha upgraded) (:sha original)))))))
+
   (testing "upgrading a single lib should also maintain :git/url and sha"
     (spit test-file-path "{}")
     (test-util/neil "dep add :lib clj-kondo/clj-kondo :sha 6ffc3934cb83d2c4fff16d84198c73b40cd8a078"

--- a/test/babashka/neil/dep_upgrade_test.clj
+++ b/test/babashka/neil/dep_upgrade_test.clj
@@ -54,6 +54,24 @@
         (is (not (= clj-kondo-original clj-kondo-upgraded)))
         (is (= fs-original fs-upgraded))))))
 
+(deftest dep-upgrade-test-using-git-tags
+  (testing "deps can be added with --latest-tag"
+    (spit test-file-path "{}")
+    (test-util/neil "dep add :lib clj-kondo/clj-kondo :latest-tag" :deps-file test-file-path)
+    (let [original (get-dep-version 'clj-kondo/clj-kondo)]
+      (is (:git/tag original))
+      (is (:git/sha original))
+      (is (:git/url original))))
+
+  (testing "deps can be added with --tag"
+    (spit test-file-path "{}")
+    (test-util/neil "dep add :lib clj-kondo/clj-kondo :tag \"v2022.03.08\"" :deps-file test-file-path)
+    (let [original (get-dep-version 'clj-kondo/clj-kondo)]
+      (is (= "v2022.03.08" (:git/tag original)))
+      (is (:git/sha original))
+      (is (:git/url original))))
+  )
+
 (deftest dep-upgrade-test-maintain-dep-source
   (testing "upgrading a :git/sha dep should maintain :git/sha"
     (spit test-file-path "{}")

--- a/test/babashka/neil/dep_upgrade_test.clj
+++ b/test/babashka/neil/dep_upgrade_test.clj
@@ -70,7 +70,28 @@
       (is (= "v2022.03.08" (:git/tag original)))
       (is (:git/sha original))
       (is (:git/url original))))
-  )
+
+  (testing "deps with :git/tag coords upgrade to latest tags"
+    (spit test-file-path "{}")
+    (test-util/neil "dep add :lib clj-kondo/clj-kondo :tag \"v2022.03.08\"" :deps-file test-file-path)
+    (let [original (get-dep-version 'clj-kondo/clj-kondo)]
+      (is (= "v2022.03.08" (:git/tag original)))
+      (test-util/neil "dep upgrade" :deps-file test-file-path)
+      (let [upgraded (get-dep-version 'clj-kondo/clj-kondo)]
+        (is (= (:git/url original) (:git/url upgraded)))
+        (is (:git/tag upgraded))
+        (is (not= (:git/tag original) (:git/tag upgraded)))
+        (is (:git/sha upgraded)))))
+
+  (testing "deps with :tag coords are also supported"
+    (spit test-file-path "{:deps {clj-kondo/clj-kondo {:tag \"v2022.03.08\" :sha \"247e538\"}}}")
+    (let [original (get-dep-version 'clj-kondo/clj-kondo)]
+      (is (= "v2022.03.08" (:tag original)))
+      (test-util/neil "dep upgrade" :deps-file test-file-path)
+      (let [upgraded (get-dep-version 'clj-kondo/clj-kondo)]
+        (is (:git/tag upgraded))
+        (is (not= (:tag original) (:git/tag upgraded)))
+        (is (:git/sha upgraded))))))
 
 (deftest dep-upgrade-test-maintain-dep-source
   (testing "upgrading a :git/sha dep should maintain :git/sha"


### PR DESCRIPTION
- [X] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
    - https://github.com/babashka/neil/issues/107

- [X] I have updated the [CHANGELOG.md](https://github.com/babashka/neil/blob/main/CHANGELOG.md) file with a description of the addressed issue.

A couple minor improvements rounding out some `neil dep upgrade` use-cases:

- `neil dep upgrade` now respects `:sha` (vs `:git/sha`) in coords, which is technically supported by tools.deps: https://clojure.org/reference/deps_and_cli#_git
- `neil dep add` now supports `--tag` and `--latest-tag`, similarly to `--sha` and `--latest-sha`
- `neil dep upgrade` now respects `:tag` and `:git/tag` coordinates (instead of setting those to the latest `:git/sha`)
- coordinates that use the prefix-less `:sha` and `:tag` will be moved to `:git/sha` and `:git/tag` when upgrading
- `neil dep upgrade`'s output can now be piped into `neil dep add`
  - you can now pipe `neil dep upgrade --dry-run` into fzf, and then back into `neil dep add`, to selectively upgrade a single dep

To test locally, be sure to specify `./neil` in both places:

```
./neil dep upgrade --dry-run | fzf | xargs ./neil dep add
```

But otherwise, once this is deployed/reinstalled:

```
neil dep upgrade --dry-run | fzf | xargs neil dep add
```

Let me know if there's anything missing here, or if any docs should be added!