### PR TITLE
fix: handle missing versions in dep add

### DIFF
--- a/neil
+++ b/neil
@@ -1103,6 +1103,7 @@ using the [major|minor|patch] subcommands.
                       [v :mvn])
                     (when-let [v (git/latest-github-sha lib)]
                       [v :git/sha])))
+            missing? (nil? version)
             mvn? (= coord-type? :mvn)
             git-sha? (= coord-type? :git/sha)
             git-tag? (= coord-type? :git/tag)
@@ -1128,6 +1129,7 @@ using the [major|minor|patch] subcommands.
             ;; [:aliases alias :extra-deps as] if alias exists
             edn-nodes (-> edn-nodes (r/assoc-in nl-path nil) str r/parse-string)
             nodes (cond
+                    missing? edn-nodes
                     mvn?
                     (r/assoc-in edn-nodes path
                                 {:mvn/version version})
@@ -1155,7 +1157,8 @@ using the [major|minor|patch] subcommands.
                         (r/assoc-in (conj path :deps/root) root))
                     nodes)
             s (str (str/trim (str nodes)) "\n")]
-        (spit (:deps-file opts) s)))))
+        (when-not missing?
+          (spit (:deps-file opts) s))))))
 
 (defn dep-versions [{:keys [opts]}]
   (let [lib (:lib opts)

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -335,6 +335,7 @@
                       [v :mvn])
                     (when-let [v (git/latest-github-sha lib)]
                       [v :git/sha])))
+            missing? (nil? version)
             mvn? (= coord-type? :mvn)
             git-sha? (= coord-type? :git/sha)
             git-tag? (= coord-type? :git/tag)
@@ -360,6 +361,7 @@
             ;; [:aliases alias :extra-deps as] if alias exists
             edn-nodes (-> edn-nodes (r/assoc-in nl-path nil) str r/parse-string)
             nodes (cond
+                    missing? edn-nodes
                     mvn?
                     (r/assoc-in edn-nodes path
                                 {:mvn/version version})
@@ -387,7 +389,8 @@
                         (r/assoc-in (conj path :deps/root) root))
                     nodes)
             s (str (str/trim (str nodes)) "\n")]
-        (spit (:deps-file opts) s)))))
+        (when-not missing?
+          (spit (:deps-file opts) s))))))
 
 (defn dep-versions [{:keys [opts]}]
   (let [lib (:lib opts)

--- a/tests.clj
+++ b/tests.clj
@@ -36,6 +36,16 @@
     (let [edn (edn/read-string (slurp tmp-file))]
       (is (-> edn :aliases :lint :deps (get 'clj-kondo/clj-kondo))))))
 
+(deftest add-dep-bogus-lib-symbol-test
+  (let [tmp-file      (test-file "deps.edn")
+        existing-deps {'clj-kondo/clj-kondo {:tag "v2022.03.08" :sha "247e538"}}]
+    (spit tmp-file (str "{:deps " existing-deps "}"))
+    ;; note this is not a qualified namespace - no version will be found, it should not be added
+    (tasks/shell "./neil add dep com.rpl.specter --deps-file" tmp-file)
+    (let [edn (edn/read-string (slurp tmp-file))]
+      ;; make sure existing deps were not deleted
+      (is (= (-> edn :deps) existing-deps)))))
+
 (deftest add-nrepl-test
   (let [{:keys [edn]} (neil "add nrepl")
         {:keys [main-opts extra-deps]} (-> edn :aliases :nrepl)]


### PR DESCRIPTION
My previous git/tag PR adjusted the dep add algorithm, but did not
handle missing versions. This introduced a deps.edn-clearing bug when a
lib was added that a version was not found for (eg. when the lib did not exist
at all due to a typo)

This is a quick fix that prevents updating the deps.edn in `add-dep`
when no version is found for the passed lib. A test was added that reproduced
and then resolved the issue.

We may also want to help the UX here with a println or some other
validation hint - let me know and I can take step in that direction as well.

-------

Please answer the following questions and leave the below in as part of your PR.

- [X] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
    - Resolves the bug reported here: https://github.com/babashka/neil/issues/131