### PR TITLE
Correct spelling of Kaocha

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ add
   dep    Alias for `neil dep add`.
   test   adds cognitect test runner to :test alias.
   build  adds tools.build build.clj file and :build alias.
-  kaocha adds kaocha test runner to :koacha alias.
+  kaocha adds kaocha test runner to :kaocha alias.
   nrepl  adds nrepl server to :nrepl alias.
 
 dep

--- a/neil
+++ b/neil
@@ -1329,7 +1329,7 @@ add
   dep    Alias for `neil dep add`.
   test   adds cognitect test runner to :test alias.
   build  adds tools.build build.clj file and :build alias.
-  kaocha adds kaocha test runner to :koacha alias.
+  kaocha adds kaocha test runner to :kaocha alias.
   nrepl  adds nrepl server to :nrepl alias.
 
 dep

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -561,7 +561,7 @@ add
   dep    Alias for `neil dep add`.
   test   adds cognitect test runner to :test alias.
   build  adds tools.build build.clj file and :build alias.
-  kaocha adds kaocha test runner to :koacha alias.
+  kaocha adds kaocha test runner to :kaocha alias.
   nrepl  adds nrepl server to :nrepl alias.
 
 dep


### PR DESCRIPTION
Fixes a typo in the spelling of 'kaocha'.

- [ ] ~~This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).~~

- [ ] ~~I have updated the [CHANGELOG.md](https://github.com/babashka/neil/blob/main/CHANGELOG.md) file with a description of the addressed issue.~~

I don't think either of these are necessary for a small change, but I can do both if you prefer.
