### PR TITLE
Handle Github rate limit reached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-- Print a message and exit when the github rate-limit is reached ([@russmatney](https://github.com/russmatney))
-- Friendlier env vars for neil github token usage ([@russmatney](https://github.com/russmatney))
+- Print a message and exit when the github rate-limit is reached ([#136](https://github.com/babashka/neil/issues/136)) ([@russmatney](https://github.com/russmatney))
+- Friendlier env vars for neil github token usage ([#136](https://github.com/babashka/neil/issues/136)) ([@russmatney](https://github.com/russmatney))
   - `BABASHKA_NEIL_DEV_GITHUB_USER` -> `NEIL_GITHUB_USER`
   - `BABASHKA_NEIL_DEV_GITHUB_TOKEN` -> `NEIL_GITHUB_TOKEN`
   The old env vars are left in-place as a fallback, but may be removed in a future version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Unreleased
 
 - Print a message and exit when the github rate-limit is reached ([@russmatney](https://github.com/russmatney))
+- Friendlier env vars for neil github token usage ([@russmatney](https://github.com/russmatney))
+  - `BABASHKA_NEIL_DEV_GITHUB_USER` -> `NEIL_GITHUB_USER`
+  - `BABASHKA_NEIL_DEV_GITHUB_TOKEN` -> `NEIL_GITHUB_TOKEN`
+  The old env vars are left in-place as a fallback, but may be removed in a future version.
 
 ## 0.1.47 (2022-10-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Print a message and exit when the github rate-limit is reached ([@russmatney](https://github.com/russmatney))
+
 ## 0.1.47 (2022-10-19)
 
 - `neil dep add` now supports `--tag` and `--latest-tag` ([@russmatney](https://github.com/russmatney))

--- a/README.md
+++ b/README.md
@@ -260,6 +260,16 @@ Load it using your preferred Emacs package manager, e.g., for Doom Emacs:
 
 ```
 
+## Github's Rate Limit
+
+Github's API has a 60 hit/hour rate-limit. The workaround for this is creating a
+[personal access
+token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+and setting two env vars:
+
+- `BABASHKA_NEIL_DEV_GITHUB_USER`
+- `BABASHKA_NEIL_DEV_GITHUB_TOKEN`
+
 ## Roadmap
 
 - Add `bb.edn`-related features for invoking `test` and `build` tasks

--- a/README.md
+++ b/README.md
@@ -267,8 +267,8 @@ Github's API has a 60 hit/hour rate-limit. The workaround for this is creating a
 token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
 and setting two env vars:
 
-- `BABASHKA_NEIL_DEV_GITHUB_USER`
-- `BABASHKA_NEIL_DEV_GITHUB_TOKEN`
+- `NEIL_GITHUB_USER`
+- `NEIL_GITHUB_TOKEN`
 
 ## Roadmap
 

--- a/README.template.md
+++ b/README.template.md
@@ -214,8 +214,8 @@ Github's API has a 60 hit/hour rate-limit. The workaround for this is creating a
 token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
 and setting two env vars:
 
-- `BABASHKA_NEIL_DEV_GITHUB_USER`
-- `BABASHKA_NEIL_DEV_GITHUB_TOKEN`
+- `NEIL_GITHUB_USER`
+- `NEIL_GITHUB_TOKEN`
 
 ## Roadmap
 

--- a/README.template.md
+++ b/README.template.md
@@ -207,6 +207,16 @@ Load it using your preferred Emacs package manager, e.g., for Doom Emacs:
 
 ```
 
+## Github's Rate Limit
+
+Github's API has a 60 hit/hour rate-limit. The workaround for this is creating a
+[personal access
+token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+and setting two env vars:
+
+- `BABASHKA_NEIL_DEV_GITHUB_USER`
+- `BABASHKA_NEIL_DEV_GITHUB_TOKEN`
+
 ## Roadmap
 
 - Add `bb.edn`-related features for invoking `test` and `build` tasks

--- a/neil
+++ b/neil
@@ -27,14 +27,16 @@
 
 (defn url-encode [s] (URLEncoder/encode s "UTF-8"))
 
-(def dev-github-user (System/getenv "BABASHKA_NEIL_DEV_GITHUB_USER"))
-(def dev-github-token (System/getenv "BABASHKA_NEIL_DEV_GITHUB_TOKEN"))
+(def github-user (or (System/getenv "NEIL_GITHUB_USER")
+                     (System/getenv "BABASHKA_NEIL_DEV_GITHUB_USER")))
+(def github-token (or (System/getenv "NEIL_GITHUB_TOKEN")
+                      (System/getenv "BABASHKA_NEIL_DEV_GITHUB_TOKEN")))
 
 (def curl-opts
-  (merge {:throw false
+  (merge {:throw      false
           :compressed (not (fs/windows?))}
-         (when (and dev-github-user dev-github-token)
-           {:basic-auth [dev-github-user dev-github-token]})))
+         (when (and github-user github-token)
+           {:basic-auth [github-user github-token]})))
 
 (defn curl-get-json [url]
   (let [response    (curl/get url curl-opts)

--- a/neil
+++ b/neil
@@ -20,7 +20,8 @@
   (:require
    [babashka.curl :as curl]
    [babashka.fs :as fs]
-   [cheshire.core :as cheshire]))
+   [cheshire.core :as cheshire]
+   [clojure.string :as string]))
 
 (import java.net.URLEncoder)
 
@@ -36,8 +37,20 @@
            {:basic-auth [dev-github-user dev-github-token]})))
 
 (defn curl-get-json [url]
-  (-> (curl/get url curl-opts)
-      :body (cheshire/parse-string true)))
+  (let [response    (curl/get url curl-opts)
+        parsed-body (-> response :body (cheshire/parse-string true))]
+    (cond
+      (and (= 403 (:status response))
+           (string/includes? url "api.github")
+           (string/includes? (:message parsed-body) "rate limit"))
+      (binding [*out* *err*]
+        (println "You've hit the github rate-limit (60 reqs/hr).
+  You can set an API Token to increase the limit.
+  See neil's readme for details.")
+        (System/exit 1))
+
+      :else
+      parsed-body)))
 
 (ns babashka.neil.git
   {:no-doc true}

--- a/src/babashka/neil/curl.clj
+++ b/src/babashka/neil/curl.clj
@@ -10,14 +10,16 @@
 
 (defn url-encode [s] (URLEncoder/encode s "UTF-8"))
 
-(def dev-github-user (System/getenv "BABASHKA_NEIL_DEV_GITHUB_USER"))
-(def dev-github-token (System/getenv "BABASHKA_NEIL_DEV_GITHUB_TOKEN"))
+(def github-user (or (System/getenv "NEIL_GITHUB_USER")
+                     (System/getenv "BABASHKA_NEIL_DEV_GITHUB_USER")))
+(def github-token (or (System/getenv "NEIL_GITHUB_TOKEN")
+                      (System/getenv "BABASHKA_NEIL_DEV_GITHUB_TOKEN")))
 
 (def curl-opts
-  (merge {:throw false
+  (merge {:throw      false
           :compressed (not (fs/windows?))}
-         (when (and dev-github-user dev-github-token)
-           {:basic-auth [dev-github-user dev-github-token]})))
+         (when (and github-user github-token)
+           {:basic-auth [github-user github-token]})))
 
 (defn curl-get-json [url]
   (let [response    (curl/get url curl-opts)


### PR DESCRIPTION
Handles github rate-limited responses in curl-get-json. We now print a message and exit. Includes some docs calling out the env vars for raising the limit.

We may prefer to nil-pun rather than exit. For now I decided to follow the way we exit in the `license` code, which similarly binds `*err*` to `*out*`, prints a message, and exits with an error code.

- [X] This PR corresponds to: https://github.com/babashka/neil/issues/136

- [X] I have updated the [CHANGELOG.md](https://github.com/babashka/neil/blob/main/CHANGELOG.md) file with a description of the addressed issue.