### PR TITLE
Add readme command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+
+## Unreleased
+- Add `neil docs readme` subcommand to create a skeleton README.md. ([@alysbrooks](https://github.com/alysbrooks))
+
 ## 0.1.47 (2022-10-19)
 
 - `neil dep add` now supports `--tag` and `--latest-tag` ([@russmatney](https://github.com/russmatney))

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ add
   dep    Alias for `neil dep add`.
   test   adds cognitect test runner to :test alias.
   build  adds tools.build build.clj file and :build alias.
-  kaocha adds kaocha test runner to :koacha alias.
+  kaocha adds kaocha test runner to :kaocha alias.
   nrepl  adds nrepl server to :nrepl alias.
 
 dep

--- a/neil
+++ b/neil
@@ -1329,7 +1329,7 @@ add
   dep    Alias for `neil dep add`.
   test   adds cognitect test runner to :test alias.
   build  adds tools.build build.clj file and :build alias.
-  kaocha adds kaocha test runner to :koacha alias.
+  kaocha adds kaocha test runner to :kaocha alias.
   nrepl  adds nrepl server to :nrepl alias.
 
 dep

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -267,6 +267,8 @@
 "]
     base))
 
+(proj/project-name  {:deps-file "/home/alys/repos/outside/neil/deps.edn"})
+
 (defn add-build [{:keys [opts] :as cmd}]
   (if (:help opts)
     (print-help cmd)
@@ -603,6 +605,9 @@ version
 
 test
   Run tests. Assumes `neil add test`. Run `neil test --help` to see all options.
+
+docs
+  readme   Creates a README.
 ")))
 
 ;; licenses
@@ -649,6 +654,29 @@ test
         (println (ex-message e))
         (System/exit 1)))))
 
+(defn create-readme [opts]
+  (let [readme "#  [Project Name]
+
+[Description]
+
+## Installation ##
+
+## Usage ##
+
+## Options ##
+
+## Examples ##
+
+## Bugs
+
+## Contributing ##
+
+## License ##
+Copyright (c) [year] [fullname]
+
+Distributed under the [LICENSE NAME]. See [LICENSE](/LICENSE)"] 
+    (spit "README.md" readme)))
+
 (defn neil-test [{:keys [opts]}]
   (neil-test/neil-test opts))
 
@@ -692,6 +720,8 @@ test
     {:cmds ["version"]
      :fn neil-version/neil-version
      :aliases {:h :help}}
+    {:cmds ["docs" "readme"]
+     :fn create-readme}
     {:cmds ["help"] :fn print-help}
     {:cmds ["test"] :fn neil-test
      ;; TODO: babashka CLI doesn't support :coerce option directly here

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -654,7 +654,7 @@ docs
         (println (ex-message e))
         (System/exit 1)))))
 
-(defn create-readme [opts]
+(defn create-readme [{:keys [opts] :as _cmd-opts}]
   (let [project-name (proj/project-name opts)
         readme (str 
                  (if project-name 

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -561,7 +561,7 @@ add
   dep    Alias for `neil dep add`.
   test   adds cognitect test runner to :test alias.
   build  adds tools.build build.clj file and :build alias.
-  kaocha adds kaocha test runner to :koacha alias.
+  kaocha adds kaocha test runner to :kaocha alias.
   nrepl  adds nrepl server to :nrepl alias.
 
 dep

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -655,9 +655,12 @@ docs
         (System/exit 1)))))
 
 (defn create-readme [opts]
-  (let [readme "#  [Project Name]
-
-[Description]
+  (let [project-name (proj/project-name opts)
+        readme (str 
+                 (if project-name 
+                   (str \# project-name )
+                   "# [Project Name]") 
+"[Description]
 
 ## Installation ##
 
@@ -674,7 +677,7 @@ docs
 ## License ##
 Copyright (c) [year] [fullname]
 
-Distributed under the [LICENSE NAME]. See [LICENSE](/LICENSE)"] 
+Distributed under the [LICENSE NAME]. See [LICENSE](/LICENSE)")] 
     (spit "README.md" readme)))
 
 (defn neil-test [{:keys [opts]}]


### PR DESCRIPTION
Added a command to create a project README like [I proposed](https://clojurians.slack.com/archives/C03KCV7TM6F/p1667449864216819) in Clojurians Slack.

This is a straightforward change in terms of code. The main questions are more about ergonomics and the interface rather than technical or implementation details:

- [ ] Should we create a `docs` subcommand (like it is now) or should `readme` be a top-level command?
- [ ] Can we fill in more information automatically?
- [ ] Could we prompt for more information? (Maybe a follow up PR?)


## Template

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [X ] I have updated the [CHANGELOG.md](https://github.com/babashka/neil/blob/main/CHANGELOG.md) file with a description of the addressed issue.
