### PR TITLE
Fix kaocha alias and script instrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 See the [New Clojure project quickstart](https://blog.michielborkent.nl/new-clojure-project-quickstart.html) blog post for a gentle introduction into `neil`.
 
+## Unreleased
+
+- Bug fix for kaocha alias and script typos 
+
 ## 0.1.54 (2023-02-04)
 
 - [#159](https://github.com/babashka/neil/issues/159): fix `pmap` + `requiring-resolve` issue

--- a/neil
+++ b/neil
@@ -1007,8 +1007,8 @@ using the [major|minor|patch] subcommands.
 
 (defn kaocha-alias []
   (format "
-{:extra-deps {lambdaisland/kaocha {:mvn/version \"%s\"}}}
- :main-opts [\"-m\" \"kaocha.runner\"]"
+{:extra-deps {lambdaisland/kaocha {:mvn/version \"%s\"}}
+ :main-opts [\"-m\" \"kaocha.runner\"]}"
           (latest-clojars-version 'lambdaisland/kaocha)))
 
 (defn add-kaocha [{:keys [opts] :as cmd}]
@@ -1021,7 +1021,7 @@ If you wish to create a `bin/kaocha` file, copy and run the following:
 
 mkdir -p bin && \\
 echo '#!/usr/bin/env bash
-clojure -M:kaocha \"$@\" > bin/kaocha && \\
+clojure -M:kaocha \"$@\"' > bin/kaocha && \\
 chmod +x bin/kaocha
 ")))))
 

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -182,8 +182,8 @@
 
 (defn kaocha-alias []
   (format "
-{:extra-deps {lambdaisland/kaocha {:mvn/version \"%s\"}}}
- :main-opts [\"-m\" \"kaocha.runner\"]"
+{:extra-deps {lambdaisland/kaocha {:mvn/version \"%s\"}}
+ :main-opts [\"-m\" \"kaocha.runner\"]}"
           (latest-clojars-version 'lambdaisland/kaocha)))
 
 (defn add-kaocha [{:keys [opts] :as cmd}]
@@ -196,7 +196,7 @@ If you wish to create a `bin/kaocha` file, copy and run the following:
 
 mkdir -p bin && \\
 echo '#!/usr/bin/env bash
-clojure -M:kaocha \"$@\" > bin/kaocha && \\
+clojure -M:kaocha \"$@\"' > bin/kaocha && \\
 chmod +x bin/kaocha
 ")))))
 


### PR DESCRIPTION
Not sure how, but my previous kaocha PR had a misplaced `}` and a missing `'`, so it breaks the deps.edn paren alignment, and the script instructions will hang. I must have been running the wrong one locally, or accidentally reverted something, to think it was working...


Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/neil/blob/main/CHANGELOG.md) file with a description of the addressed issue.
