### PR TITLE
`neil new`: link to upstream docs for list of built in templates

### DIFF
--- a/src/babashka/neil/new.clj
+++ b/src/babashka/neil/new.clj
@@ -152,7 +152,10 @@ https://github.com/seancorfield/deps-new/blob/develop/doc/options.md
 
 Both built-in and external templates are supported. Built-in templates use
 unqualified names (e.g. scratch) whereas external templates use fully-qualified
-names (e.g. io.github.kit/kit-clj).
+names (e.g. io.github.kit/kit-clj). The list of valid built-in templates can be
+found in the deps-new README:
+
+https://github.com/seancorfield/deps-new/blob/develop/README.md
 
 If an external template is provided, the babashka.deps/add-deps function will be
 called automatically before running org.corfield.new/create. The deps for the


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
    - [x] No issue, but discussed on Slack: https://clojurians.slack.com/archives/C019ZQSPYG6/p1676654582925489?thread_ts=1676645855.709469&cid=C019ZQSPYG6

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/neil/blob/main/CHANGELOG.md) file with a description of the addressed issue.

### Should this be merged?

This PR contains proposed helptext changes incorporating suggestions from @seancorfield. I think we _could_ get something better if we put in a bit more time.

### Alternatives

#166 generates helptext to include list of built in templates.