### PR TITLE
`neil new`: print built-in templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 See the [New Clojure project quickstart](https://blog.michielborkent.nl/new-clojure-project-quickstart.html) blog post for a gentle introduction into `neil`.
 
+## Unreleased
+
+- [#166]: Update `neil new -h` output to include list of provided templates
+
+[#166]: https://github.com/babashka/neil/pull/166
+
 ## 0.1.56 (2023-02-17)
 
 - [#163](https://github.com/babashka/neil/issues/163): Upgrade libraries, including deps-new to 0.5.0, which no longer uses [@seancorfield](https://github.com/seancorfield)'s tools.build wrapper in project templates

--- a/neil
+++ b/neil
@@ -273,9 +273,9 @@
 
 (defn- built-in-templates []
   (require 'org.corfield.new)
-  (let [blacklist #{'create}]
+  (let [non-templates #{'create}]
     (->> (ns-publics 'org.corfield.new)
-         (remove (fn [[sym _]] (contains? blacklist sym)))
+         (remove (fn [[sym _]] (contains? non-templates sym)))
          (into {}))))
 
 (defn- github-repo-http-url [lib]

--- a/neil
+++ b/neil
@@ -271,6 +271,13 @@
   [template]
   (contains? (set (map name (keys (ns-publics 'org.corfield.new)))) template))
 
+(defn- built-in-templates []
+  (require 'org.corfield.new)
+  (let [blacklist #{'create}]
+    (->> (ns-publics 'org.corfield.new)
+         (remove (fn [[sym _]] (contains? blacklist sym)))
+         (into {}))))
+
 (defn- github-repo-http-url [lib]
   (str "https://github.com/" (git/clean-github-lib lib)))
 
@@ -399,7 +406,10 @@
   ((req-resolve 'org.corfield.new/create) create-opts))
 
 (defn print-new-help []
-  (println (str/trim "
+  (println
+   (str/join "\n\n"
+             (map str/trim
+                  ["
 Usage: neil new [template] [name] [target-dir] [options]
 
 Runs the org.corfield.new/create function from deps-new.
@@ -410,8 +420,12 @@ https://github.com/seancorfield/deps-new/blob/develop/doc/options.md
 
 Both built-in and external templates are supported. Built-in templates use
 unqualified names (e.g. scratch) whereas external templates use fully-qualified
-names (e.g. io.github.kit/kit-clj).
-
+names (e.g. io.github.kit/kit-clj)."
+                   (str
+                    "The provided built-in templates are:\n\n"
+                    (str/join "\n" (for [sym (sort (keys (built-in-templates)))]
+                                     (str "    " sym))))
+                   "
 If an external template is provided, the babashka.deps/add-deps function will be
 called automatically before running org.corfield.new/create. The deps for the
 template are inferred automatically from the template name. The following
@@ -440,7 +454,7 @@ options can be used to control the add-deps behavior:
 
 Examples:
   neil new scratch foo --overwrite
-  neil new io.github.rads/neil-new-test-template foo2 --latest-sha")))
+  neil new io.github.rads/neil-new-test-template foo2 --latest-sha"]))))
 
 (defn- deps-new-set-classpath
   "Sets the java.class.path property.

--- a/src/babashka/neil/new.clj
+++ b/src/babashka/neil/new.clj
@@ -15,9 +15,9 @@
 
 (defn- built-in-templates []
   (require 'org.corfield.new)
-  (let [blacklist #{'create}]
+  (let [non-templates #{'create}]
     (->> (ns-publics 'org.corfield.new)
-         (remove (fn [[sym _]] (contains? blacklist sym)))
+         (remove (fn [[sym _]] (contains? non-templates sym)))
          (into {}))))
 
 (defn- github-repo-http-url [lib]

--- a/src/babashka/neil/new.clj
+++ b/src/babashka/neil/new.clj
@@ -13,6 +13,13 @@
   [template]
   (contains? (set (map name (keys (ns-publics 'org.corfield.new)))) template))
 
+(defn- built-in-templates []
+  (require 'org.corfield.new)
+  (let [blacklist #{'create}]
+    (->> (ns-publics 'org.corfield.new)
+         (remove (fn [[sym _]] (contains? blacklist sym)))
+         (into {}))))
+
 (defn- github-repo-http-url [lib]
   (str "https://github.com/" (git/clean-github-lib lib)))
 
@@ -141,7 +148,10 @@
   ((req-resolve 'org.corfield.new/create) create-opts))
 
 (defn print-new-help []
-  (println (str/trim "
+  (println
+   (str/join "\n\n"
+             (map str/trim
+                  ["
 Usage: neil new [template] [name] [target-dir] [options]
 
 Runs the org.corfield.new/create function from deps-new.
@@ -152,8 +162,12 @@ https://github.com/seancorfield/deps-new/blob/develop/doc/options.md
 
 Both built-in and external templates are supported. Built-in templates use
 unqualified names (e.g. scratch) whereas external templates use fully-qualified
-names (e.g. io.github.kit/kit-clj).
-
+names (e.g. io.github.kit/kit-clj)."
+                   (str
+                    "The provided built-in templates are:\n\n"
+                    (str/join "\n" (for [sym (sort (keys (built-in-templates)))]
+                                     (str "    " sym))))
+                   "
 If an external template is provided, the babashka.deps/add-deps function will be
 called automatically before running org.corfield.new/create. The deps for the
 template are inferred automatically from the template name. The following
@@ -182,7 +196,7 @@ options can be used to control the add-deps behavior:
 
 Examples:
   neil new scratch foo --overwrite
-  neil new io.github.rads/neil-new-test-template foo2 --latest-sha")))
+  neil new io.github.rads/neil-new-test-template foo2 --latest-sha"]))))
 
 (defn- deps-new-set-classpath
   "Sets the java.class.path property.


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
    - [x] No issue, but discussed on Slack: https://clojurians.slack.com/archives/C019ZQSPYG6/p1676654582925489?thread_ts=1676645855.709469&cid=C019ZQSPYG6

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/neil/blob/main/CHANGELOG.md) file with a description of the addressed issue.

### Generated helptext

In this PR; the generated helptext is:

<details><summary><code>$ neil-dev new -h</code></summary>
<pre><code>
Usage: neil new [template] [name] [target-dir] [options]

Runs the org.corfield.new/create function from deps-new.
Usage: neil new [template] [name] [target-dir] [options]

Runs the org.corfield.new/create function from deps-new.

All of the deps-new options can be provided as CLI options:

https://github.com/seancorfield/deps-new/blob/develop/doc/options.md

Both built-in and external templates are supported. Built-in templates use
unqualified names (e.g. scratch) whereas external templates use fully-qualified
names (e.g. io.github.kit/kit-clj).

Provided built-in templates are:

    app
    lib
    pom
    scratch
    template

If an external template is provided, the babashka.deps/add-deps function will be
called automatically before running org.corfield.new/create. The deps for the
template are inferred automatically from the template name. The following
options can be used to control the add-deps behavior:

  --local/root
    Override the :deps map to use the provided :local/root path.

  --git/url
    Override the :git/url in the :deps map. If no URL is provided, a template
    name starting with io.github or com.github is expected and the URL will
    point to GitHub.

  --git/tag
    Override the :git/tag in the :deps map. If no SHA or tag is provided, the
    latest tag from the default branch of :git/url will be used.

  --sha
  --git/sha
    Override the :git/sha in the :deps map. If no SHA or tag is provided, the
    latest tag from the default branch of :git/url will be used.

  --latest-sha
    Override the :git/sha in the :deps map with the latest SHA from the
    default branch of :git/url.

Examples:
  neil new scratch foo --overwrite
  neil new io.github.rads/neil-new-test-template foo2 --latest-sha
</code></pre>
</details>


### Should this be merged?

I'm not sure whether this is the way to go to look up valid values template values:

```clojure
(defn- built-in-templates []
  (require 'org.corfield.new)
  (let [blacklist #{'create}]
    (->> (ns-publics 'org.corfield.new)
         (remove (fn [[sym _]] (contains? blacklist sym)))
         (into {}))))
```

`deps-new` could easily add another public var in `org.corfield.new`, and we'll happily assume it's a valid template.

### Alternatives

#165 solves this by linking to upstream documentation.