### PR TITLE
`neil dep add`: add latest unstable version if no stable versions are found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 See the [New Clojure project quickstart](https://blog.michielborkent.nl/new-clojure-project-quickstart.html) blog post for a gentle introduction into `neil`.
 
+## Unreleased
+
+- [#177](https://github.com/babashka/neil/issues/177): `neil dep add`: add latest unstable version if no stable versions are found ([@teodorlu](https://github.com/teodorlu))
+
 ## 0.1.59 (2023-03-09)
 
 - [#173](https://github.com/babashka/neil/issues/173): `neil new`: Support Git repos without tags

--- a/neil
+++ b/neil
@@ -921,9 +921,12 @@ using the [major|minor|patch] subcommands.
          (map :version)
          (take limit))))
 
-(defn latest-clojars-version
+(defn latest-stable-clojars-version
   [qlib]
   (first-stable-version (clojars-versions qlib {:limit 100})))
+
+(defn latest-clojars-version [qlib]
+  (first (clojars-versions qlib {:limit 100})))
 
 (defn- search-mvn [qlib limit]
   (:response
@@ -939,8 +942,11 @@ using the [major|minor|patch] subcommands.
          :docs
          (map :v))))
 
-(defn latest-mvn-version [qlib]
+(defn latest-stable-mvn-version [qlib]
   (first-stable-version (mvn-versions qlib {:limit 100})))
+
+(defn latest-mvn-version [qlib]
+  (first (mvn-versions qlib {:limit 100})))
 
 (def deps-template
   (str/triml "
@@ -1042,7 +1048,7 @@ using the [major|minor|patch] subcommands.
   (format "
 {:extra-deps {lambdaisland/kaocha {:mvn/version \"%s\"}}
  :main-opts [\"-m\" \"kaocha.runner\"]}"
-          (latest-clojars-version 'lambdaisland/kaocha)))
+          (latest-stable-clojars-version 'lambdaisland/kaocha)))
 
 (defn add-kaocha [{:keys [opts] :as cmd}]
   (if (:help opts)
@@ -1062,7 +1068,7 @@ chmod +x bin/kaocha
   (format "
 {:extra-deps {nrepl/nrepl {:mvn/version \"%s\"}}
  :main-opts [\"-m\" \"nrepl.cmdline\" \"--interactive\" \"--color\"]}"
-          (latest-clojars-version 'nrepl/nrepl)))
+          (latest-stable-clojars-version 'nrepl/nrepl)))
 
 (defn add-nrepl [{:keys [opts] :as cmd}]
   (if (:help opts)
@@ -1214,12 +1220,16 @@ chmod +x bin/kaocha
                   (or
                    (when-let [v (:version opts)]
                      [v :mvn])
+                   (when-let [v (latest-stable-clojars-version lib)]
+                     [v :mvn])
+                   (when-let [v (latest-stable-mvn-version lib)]
+                     [v :mvn])
+                   (when-let [v (git/latest-github-sha lib)]
+                     [v :git/sha])
                    (when-let [v (latest-clojars-version lib)]
                      [v :mvn])
                    (when-let [v (latest-mvn-version lib)]
-                     [v :mvn])
-                   (when-let [v (git/latest-github-sha lib)]
-                     [v :git/sha])))
+                     [v :mvn])))
             missing? (nil? version)
             mvn? (= coord-type? :mvn)
             git-sha? (= coord-type? :git/sha)

--- a/test/babashka/neil/dep_add_test.clj
+++ b/test/babashka/neil/dep_add_test.clj
@@ -5,4 +5,5 @@
 
 (deftest latest-version-test
   (is (= "1.0.5" (neil/latest-stable-clojars-version 'hiccup/hiccup)))
+  (is (= "2.0.0-alpha2" (neil/latest-clojars-version 'hiccup/hiccup)))
   (is (= "1.11.1" (neil/latest-stable-mvn-version 'org.clojure/clojure))))

--- a/test/babashka/neil/dep_add_test.clj
+++ b/test/babashka/neil/dep_add_test.clj
@@ -4,5 +4,5 @@
    [clojure.test :as t :refer [deftest is]]))
 
 (deftest latest-version-test
-  (is (= "1.0.5" (neil/latest-clojars-version 'hiccup/hiccup)))
-  (is (= "1.11.1" (neil/latest-mvn-version 'org.clojure/clojure))))
+  (is (= "1.0.5" (neil/latest-stable-clojars-version 'hiccup/hiccup)))
+  (is (= "1.11.1" (neil/latest-stable-mvn-version 'org.clojure/clojure))))


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
    - https://github.com/babashka/neil/issues/177

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/neil/blob/main/CHANGELOG.md) file with a description of the addressed issue.

-----

## Semantics

- Without this PR, we fail silently when `neil dep add LIB` is called, and there are no stable versions available for  `LIB`.
- With this PR, we first check for stable versions, then fall back to the first unstable version.

```
$ ls
$ neil-dev dep search ham-fisted
:lib com.cnuernber/ham-fisted :version "1.000-beta-90" :description nil
$ neil-dev dep add com.cnuernber/ham-fisted
$ cat deps.edn
{:deps {com.cnuernber/ham-fisted {:mvn/version "1.000-beta-90"}}
 :aliases {}}
```

## Considerations

I renamed the old `neil/latest-clojars-version` to `neil/latest-stable-clojars-version`, and added a new `neil/latest-clojars-version` that accepts both stable and unstable versions.

The fallback logic as implemented increases the time a `neil dep add` call takes, by introducing two extra network requests:

```clojure
:else
(or
 (when-let [v (:version opts)]
   [v :mvn])
 (when-let [v (latest-stable-clojars-version lib)]
   [v :mvn])
 (when-let [v (latest-stable-mvn-version lib)]
   [v :mvn])
 (when-let [v (git/latest-github-sha lib)]
   [v :git/sha])
 (when-let [v (latest-clojars-version lib)]
   [v :mvn])
 (when-let [v (latest-mvn-version lib)]
   [v :mvn]))
```