### PR TITLE
`neil dep upgrade`: allow upgrading from unstable version to more recent unstable version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 See the [New Clojure project quickstart](https://blog.michielborkent.nl/new-clojure-project-quickstart.html) blog post for a gentle introduction into `neil`.
 
+## Unreleased
+
+- [#180](https://github.com/babashka/neil/issues/180): `neil dep upgrade`: allow upgrading from an unstable version to the latest unstable version ([@teodorlu](https://github.com/teodorlu))
+
 ## 0.1.60 (2023-03-22)
 
 - [#177](https://github.com/babashka/neil/issues/177): `neil dep add`: add latest unstable version if no stable versions are found ([@teodorlu](https://github.com/teodorlu))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,8 @@ See the [New Clojure project quickstart](https://blog.michielborkent.nl/new-cloj
 
 ## Unreleased
 
-<<<<<<< HEAD
 - [#180](https://github.com/babashka/neil/issues/180): `neil dep upgrade`: allow upgrading from an unstable version to the latest unstable version ([@teodorlu](https://github.com/teodorlu))
-=======
 - [#181](https://github.com/babashka/neil/issues/181): fix `neil --version`
->>>>>>> origin/main
 
 ## 0.1.60 (2023-03-22)
 

--- a/bb.edn
+++ b/bb.edn
@@ -44,10 +44,6 @@
            :requires ([babashka.neil.test-runner])
            :task (exec 'babashka.neil.test-runner/run-tests)}
 
-  test:teodor {:depends [gen-script]
-               :requires ([babashka.neil.test-runner])
-               :task (babashka.neil.test-runner/run-tests {:nses (pr-str '[babashka.neil.dep-upgrade-test])})}
-
   test:clj {:task (apply clojure "-M:test" *command-line-args*)}
 
   test:emacs {:extra-paths ["."]

--- a/bb.edn
+++ b/bb.edn
@@ -44,6 +44,10 @@
            :requires ([babashka.neil.test-runner])
            :task (exec 'babashka.neil.test-runner/run-tests)}
 
+  test:teodor {:depends [gen-script]
+               :requires ([babashka.neil.test-runner])
+               :task (babashka.neil.test-runner/run-tests {:nses (pr-str '[babashka.neil.dep-upgrade-test])})}
+
   test:clj {:task (apply clojure "-M:test" *command-line-args*)}
 
   test:emacs {:extra-paths ["."]

--- a/neil
+++ b/neil
@@ -907,15 +907,13 @@ using the [major|minor|patch] subcommands.
    (format "https://clojars.org/api/artifacts/%s"
            qlib)))
 
-(defn first-stable-version [versions]
+(defn stable-version? [version]
   (let [vparse (req-resolve 'version-clj.core/parse)]
-    (some (fn [version]
-            (let [{:keys [qualifiers]} (vparse version)]
-              (when-not
-                  ;; assume all qualifiers indicate non-stable version
-                  (some #{"rc" "alpha" "beta" "snapshot" "milestone"} qualifiers)
-                version)))
-          versions)))
+    (not (some #{"rc" "alpha" "beta" "snapshot" "milestone"}
+               (:qualifiers (vparse version))))))
+
+(defn first-stable-version [versions]
+  (->> versions (filter stable-version?) first))
 
 (defn clojars-versions [qlib {:keys [limit] :or {limit 10}}]
   (let [body (get-clojars-artifact qlib)]
@@ -1380,7 +1378,13 @@ details on the search syntax.")))
 
   Returns a `latest` coordinate as a map with `:mvn/version` or `:git/sha`.
   Note that this is not a full dep coordinate - we rely on `dep-add` later to include
-  `:git/url`, for example."
+  `:git/url`, for example.
+  
+  Upgrade semantics:
+
+    1. A version will not be superseded by an older version
+    2. A stable version will only be superseded by another stable version
+    3. Unstable versions will be replaced by the latest version, whether stable or unstable."
   [{:keys [current lib] :as _dep-update}]
   (let [v-older? (req-resolve 'version-clj.core/older?)]
     (cond
@@ -1399,11 +1403,14 @@ details on the search syntax.")))
           {:git/sha sha}))
 
       (:mvn/version current)
-      (when-let [version (or (first-stable-version (clojars-versions lib {:limit 100}))
-                             (first-stable-version (mvn-versions lib {:limit 100})))]
-        ;; if current version is newer than latest stable release, leave it
-        (when (v-older? (:mvn/version current) version)
-          {:mvn/version version})))))
+      (let [first-acceptable (if (stable-version? (:mvn/version current))
+                               first-stable-version
+                               first)]
+        (when-let [latest-version (or (first-acceptable (clojars-versions lib {:limit 100}))
+                                      (first-acceptable (mvn-versions lib {:limit 100})))]
+          ;; if current version is newer than latest release, leave it
+          (when (v-older? (:mvn/version current) latest-version)
+            {:mvn/version latest-version}))))))
 
 (defn opts->specified-deps
   "Returns all :deps and :alias :extra-deps for the deps.edn indicated by `opts`."

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -49,15 +49,13 @@
    (format "https://clojars.org/api/artifacts/%s"
            qlib)))
 
-(defn first-stable-version [versions]
+(defn stable-version? [version]
   (let [vparse (req-resolve 'version-clj.core/parse)]
-    (some (fn [version]
-            (let [{:keys [qualifiers]} (vparse version)]
-              (when-not
-                  ;; assume all qualifiers indicate non-stable version
-                  (some #{"rc" "alpha" "beta" "snapshot" "milestone"} qualifiers)
-                version)))
-          versions)))
+    (not (some #{"rc" "alpha" "beta" "snapshot" "milestone"}
+               (:qualifiers (vparse version))))))
+
+(defn first-stable-version [versions]
+  (->> versions (filter stable-version?) first))
 
 (defn clojars-versions [qlib {:keys [limit] :or {limit 10}}]
   (let [body (get-clojars-artifact qlib)]

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -540,6 +540,11 @@ details on the search syntax.")))
         (when-let [sha (git/latest-github-sha lib)]
           {:git/sha sha}))
 
+      ;; Proposed semantic:
+      ;;
+      ;; 1. When a stable version is installed, upgrade to latest stable.
+      ;; 2. When an unstable version is installed, upgrade to latest version - stable or unstable.
+
       (:mvn/version current)
       (when-let [version (or (first-stable-version (clojars-versions lib {:limit 100}))
                              (first-stable-version (mvn-versions lib {:limit 100})))]

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -513,6 +513,30 @@ details on the search syntax.")))
       (-> (str/replace git-url "https://github.com/" "")
           symbol))))
 
+(defn preferred-upgrade-version
+  "Given a current version and a list of optional versions, either return an
+  upgrade to recommend, or nil if upgrading is not recommended.
+
+  Upgrade semantics:
+
+  1. A version will not be replaced by an older version
+  2. A stable version will not be replaced by an unstable version
+  3. An unstable version will preferrably be replaced by a more recent stable
+     version (preferred), otherwise a more recent unstable version if present."
+  [current versions]
+  (let [latest-stable-version (first-stable-version versions)
+        latest-version (first versions)
+        v-older? (req-resolve 'version-clj.core/older?)]
+    (cond (v-older? current latest-stable-version)
+          latest-stable-version
+
+          (and (not (stable-version? current))
+               (v-older? current latest-version))
+          latest-version
+
+          :else
+          nil)))
+
 (defn dep->latest
   "Expects a `dep-upgrade` map, with `:lib` and `:current` keys.
   `:current` is the dep's current coordinates, like `{:mvn/version \"some-version\"}`

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -520,7 +520,13 @@ details on the search syntax.")))
 
   Returns a `latest` coordinate as a map with `:mvn/version` or `:git/sha`.
   Note that this is not a full dep coordinate - we rely on `dep-add` later to include
-  `:git/url`, for example."
+  `:git/url`, for example.
+  
+  Upgrade semantics:
+
+    1. A version will not be superseded by an older version
+    2. A stable version will only be superseded by another stable version
+    3. Unstable versions will be replaced by the latest version, whether stable or unstable."
   [{:keys [current lib] :as _dep-update}]
   (let [v-older? (req-resolve 'version-clj.core/older?)]
     (cond
@@ -538,17 +544,15 @@ details on the search syntax.")))
         (when-let [sha (git/latest-github-sha lib)]
           {:git/sha sha}))
 
-      ;; Proposed semantic:
-      ;;
-      ;; 1. When a stable version is installed, upgrade to latest stable.
-      ;; 2. When an unstable version is installed, upgrade to latest version - stable or unstable.
-
       (:mvn/version current)
-      (when-let [version (or (first-stable-version (clojars-versions lib {:limit 100}))
-                             (first-stable-version (mvn-versions lib {:limit 100})))]
-        ;; if current version is newer than latest stable release, leave it
-        (when (v-older? (:mvn/version current) version)
-          {:mvn/version version})))))
+      (let [first-acceptable (if (stable-version? (:mvn/version current))
+                               first-stable-version
+                               first)]
+        (when-let [latest-version (or (first-acceptable (clojars-versions lib {:limit 100}))
+                                      (first-acceptable (mvn-versions lib {:limit 100})))]
+          ;; if current version is newer than latest release, leave it
+          (when (v-older? (:mvn/version current) latest-version)
+            {:mvn/version latest-version}))))))
 
 (defn opts->specified-deps
   "Returns all :deps and :alias :extra-deps for the deps.edn indicated by `opts`."

--- a/test/babashka/neil/dep_upgrade_test.clj
+++ b/test/babashka/neil/dep_upgrade_test.clj
@@ -45,7 +45,17 @@
 
       ;; after a non-dry-run, the version should be changed
       (test-util/neil "dep upgrade" :deps-file test-file-path)
-      (is (not (= clj-kondo-version-original (get-dep-version 'clj-kondo/clj-kondo)))))))
+      (is (not (= clj-kondo-version-original (get-dep-version 'clj-kondo/clj-kondo))))))
+
+  (testing "Update logic: update to new stable versions."
+    (let [versions ["1.12.0-alpha2" "1.12.0-alpha1" "1.11.2" "1.11.2-alpha1" "1.11.1" "1.11.0" "1.11.0-alpha1"]]
+      (is (= "1.11.2" (neil/preferred-upgrade-version "1.11.1" versions)))
+      (is (= "1.11.2" (neil/preferred-upgrade-version "1.11.0" versions)))
+      (is (= "1.11.2" (neil/preferred-upgrade-version "1.11.0-alpha1" versions)))))
+
+  (testing "Update logic: when on unstable and a more recent unstable is available, update."
+    (let [versions ["1.12.0-alpha2" "1.12.0-alpha1" "1.11.2" "1.11.2-alpha1" "1.11.1" "1.11.0" "1.11.0-alpha1"]]
+      (is (= "1.12.0-alpha2" (neil/preferred-upgrade-version "1.12.0-alpha1" versions))))))
 
 (deftest dep-upgrade-test-one-lib
   (testing "specifying :lib only updates one dep"

--- a/test/babashka/neil/dep_upgrade_test.clj
+++ b/test/babashka/neil/dep_upgrade_test.clj
@@ -23,7 +23,8 @@
 
 (deftest stable-version-test
   (is (true? (neil/stable-version? "1.11")))
-  (is (false? (neil/stable-version? "v2-alpha-263-g89da9d11"))))
+  (is (false? (neil/stable-version? "v2-alpha-263-g89da9d11")))
+  (is (= "1.11" (neil/first-stable-version ["v2-alpha-263-g89da9d11" "1.11"]))))
 
 (deftest dep-upgrade-test
   (testing "a fresh project is up-to-date"

--- a/test/babashka/neil/dep_upgrade_test.clj
+++ b/test/babashka/neil/dep_upgrade_test.clj
@@ -21,6 +21,10 @@
       (->> (map (comp #(get % dep-name) :extra-deps second))
            (into #{}))))
 
+(deftest stable-version-test
+  (is (true? (neil/stable-version? "1.11")))
+  (is (false? (neil/stable-version? "v2-alpha-263-g89da9d11"))))
+
 (deftest dep-upgrade-test
   (testing "a fresh project is up-to-date"
     (spit test-file-path "{}")


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
    - https://github.com/babashka/neil/issues/180

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/neil/blob/main/CHANGELOG.md) file with a description of the addressed issue.

### Rationale

When working with libraries where there is no stable version released, it's nice to be able to upgrade to most recent unstable version. We could allow this with `neil dep upgrade`.

### Proposed semantics

1. A version will never be superseded by an older version
2. A stable version will be superseded by stable versions only
3. Unstable versions will be replaced by the latest version - whether stable or unstable.
