### PR TITLE
Fix tests by referring to latest hiccup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ See the [New Clojure project quickstart](https://blog.michielborkent.nl/new-cloj
 ## Unreleased
 
 - [#181](https://github.com/babashka/neil/issues/181): fix `neil --version`
+- fix tests by referring to latest hiccup ([@teodorlu](https://github.com/teodorlu))
 
 ## 0.1.60 (2023-03-22)
 

--- a/test/babashka/neil/dep_add_test.clj
+++ b/test/babashka/neil/dep_add_test.clj
@@ -5,5 +5,5 @@
 
 (deftest latest-version-test
   (is (= "1.0.5" (neil/latest-stable-clojars-version 'hiccup/hiccup)))
-  (is (= "2.0.0-alpha2" (neil/latest-clojars-version 'hiccup/hiccup)))
+  (is (= "2.0.0-RC1" (neil/latest-clojars-version 'hiccup/hiccup)))
   (is (= "1.11.1" (neil/latest-stable-mvn-version 'org.clojure/clojure))))


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/neil/blob/main/CHANGELOG.md) file with a description of the addressed issue.

We have a hard-coded reference to hiccup version in our tests. A new version of hiccup was released, breaking the tests. This PR updates the hiccup version to the latest version, fixing the tests.