### PR TITLE
`neil dep upgrade`: upgrade unstable versions to more recent unstable versions (attempt 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ See the [New Clojure project quickstart](https://blog.michielborkent.nl/new-cloj
 
 - [#181](https://github.com/babashka/neil/issues/181): fix `neil --version`
 - fix tests by referring to latest hiccup ([@teodorlu](https://github.com/teodorlu))
+- [#180](https://github.com/babashka/neil/issues/180): `neil dep upgrade`: allow upgrading from an unstable version to the latest unstable version ([@teodorlu](https://github.com/teodorlu))
 
 ## 0.1.60 (2023-03-22)
 

--- a/deps.edn
+++ b/deps.edn
@@ -21,4 +21,12 @@
                  :git/tag "v0.5.1"
                  :git/sha "dfb30dd"}}
    :main-opts ["-m" "cognitect.test-runner"]
-   :exec-fn cognitect.test-runner.api/test}}}
+   :exec-fn cognitect.test-runner.api/test}
+
+  :dev
+  {:extra-paths ["test"]
+   :extra-deps {io.github.cognitect-labs/test-runner
+                {:git/url "https://github.com/cognitect-labs/test-runner"
+                 :git/tag "v0.5.1"
+                 :git/sha "dfb30dd"}}}
+  }}

--- a/neil
+++ b/neil
@@ -910,7 +910,7 @@ using the [major|minor|patch] subcommands.
 
 (defn stable-version?
   [version-str]
-  (let [vparse (req-resolve 'version-clj.core/parse)]
+  (let [vparse (req-resolve 'version-clj.core/parse)] ; We lazy-load version-clj to improve average script startup time
     (empty? (set/intersection (:qualifiers (vparse version-str))
                               #{"rc" "alpha" "beta" "snapshot" "milestone"}))))
 
@@ -1387,7 +1387,7 @@ details on the search syntax.")))
 
 (defn- dep->latest-stable
   [{:keys [current lib] :as _dep-update}]
-  (let [v-older? (req-resolve 'version-clj.core/older?)]
+  (let [v-older? (req-resolve 'version-clj.core/older?)] ; We lazy-load version-clj to improve average script startup time
     (cond
       (or (:git/tag current) (:tag current))
       (let [lib (or (git-url->lib (:git/url current))

--- a/neil
+++ b/neil
@@ -1388,7 +1388,7 @@ details on the search syntax.")))
     (dep->upgrade {:lib 'clj-kondo/clj-kondo :current {:git/sha \"247e538\"}})
     ;; => {:git/sha \"...\"}
   "
-  [{:keys [lib current] :as dep}]
+  [{:keys [lib current]}]
   ;; for now, just upgrade to stable versions
   (let [current (set/rename-keys current {:sha :git/sha
                                           :tag :git/tag})]

--- a/neil
+++ b/neil
@@ -1385,16 +1385,7 @@ details on the search syntax.")))
       (-> (str/replace git-url "https://github.com/" "")
           symbol))))
 
-(defn dep->latest-stable
-  "Expects a `dep-upgrade` map, with `:lib` and `:current` keys.
-  `:current` is the dep's current coordinates, like `{:mvn/version \"some-version\"}`
-  or `{:git/sha \"sha-blah\"}`.
-
-  Returns a `latest` coordinate as a map with `:mvn/version` or `:git/sha` if a
-  valid upgrade is found, `nil` otherwise.
-
-  Note that this is not a full dep coordinate - we rely on `dep-add` later to include
-  `:git/url`, for example."
+(defn- dep->latest-stable
   [{:keys [current lib] :as _dep-update}]
   (let [v-older? (req-resolve 'version-clj.core/older?)]
     (cond

--- a/neil
+++ b/neil
@@ -1413,8 +1413,8 @@ details on the search syntax.")))
       ;; if `current` is a stable maven/clojars version, find the latest stable
       ;; maven clojars dep
       (and (:mvn/version current) (stable-version? (:mvn/version current)))
-      (when-let [version (or (first-stable-version (clojars-versions lib {:limit 100}))
-                             (first-stable-version (mvn-versions lib {:limit 100})))]
+      (when-let [version (or (first (filter stable-version? (clojars-versions lib {:limit 100})))
+                             (first (filter stable-version? (mvn-versions lib {:limit 100}))))]
         ;; only upgrade to a newer version than the current. Useful when
         ;; developing a new version locally.
         (let [v-older? (req-resolve 'version-clj.core/older?)]

--- a/neil
+++ b/neil
@@ -871,7 +871,8 @@ using the [major|minor|patch] subcommands.
    [babashka.neil.version :as neil-version]
    [borkdude.rewrite-edn :as r]
    [clojure.edn :as edn]
-   [clojure.string :as str]))
+   [clojure.string :as str]
+   [clojure.set :as set]))
 
 (def spec {:lib {:desc "Fully qualified library name."}
            :version {:desc "Optional. When not provided, picks newest version from Clojars or Maven Central."
@@ -907,15 +908,26 @@ using the [major|minor|patch] subcommands.
    (format "https://clojars.org/api/artifacts/%s"
            qlib)))
 
-(defn first-stable-version [versions]
+(defn stable-version?
+  [version-str]
   (let [vparse (req-resolve 'version-clj.core/parse)]
-    (some (fn [version]
-            (let [{:keys [qualifiers]} (vparse version)]
-              (when-not
-                  ;; assume all qualifiers indicate non-stable version
-                  (some #{"rc" "alpha" "beta" "snapshot" "milestone"} qualifiers)
-                version)))
-          versions)))
+    (empty? (set/intersection (:qualifiers (vparse version-str))
+                              #{"rc" "alpha" "beta" "snapshot" "milestone"}))))
+
+(comment
+  (stable-version? "1.0.4")
+  ;; => true
+  (stable-version? "1.0.5")
+  ;; => true
+  (stable-version? "2.0.0-RC1")
+  ;; => false
+  )
+
+(defn first-stable-version [versions]
+  (some (fn [version]
+          (when (stable-version? version)
+            version))
+        versions))
 
 (defn clojars-versions [qlib {:keys [limit] :or {limit 10}}]
   (let [body (get-clojars-artifact qlib)]
@@ -1373,12 +1385,14 @@ details on the search syntax.")))
       (-> (str/replace git-url "https://github.com/" "")
           symbol))))
 
-(defn dep->latest
+(defn dep->latest-stable
   "Expects a `dep-upgrade` map, with `:lib` and `:current` keys.
   `:current` is the dep's current coordinates, like `{:mvn/version \"some-version\"}`
   or `{:git/sha \"sha-blah\"}`.
 
-  Returns a `latest` coordinate as a map with `:mvn/version` or `:git/sha`.
+  Returns a `latest` coordinate as a map with `:mvn/version` or `:git/sha` if a
+  valid upgrade is found, `nil` otherwise.
+
   Note that this is not a full dep coordinate - we rely on `dep-add` later to include
   `:git/url`, for example."
   [{:keys [current lib] :as _dep-update}]
@@ -1404,6 +1418,17 @@ details on the search syntax.")))
         ;; if current version is newer than latest stable release, leave it
         (when (v-older? (:mvn/version current) version)
           {:mvn/version version})))))
+
+(defn dep->upgrade
+  "Given a lib (hiccup/hiccup) and a version ({:mvn/version \"1.0.4\"}), return an
+  upgrade ({:mvn/version \"1.0.5\"}), otherwise return nil.
+
+    (dep->latest-stable {:lib 'hiccup/hiccup
+                         :current {:mvn/version \"1.0.4\"}})
+  "
+  [{:keys [lib current]}]
+  ;; for now, just upgrade to stable versions
+  (dep->latest-stable {:lib lib :current current}))
 
 (defn opts->specified-deps
   "Returns all :deps and :alias :extra-deps for the deps.edn indicated by `opts`."
@@ -1484,7 +1509,7 @@ Examples:
         alias         (some-> opts :alias)
         deps-to-check (opts->specified-deps opts)
         upgrades      (->> deps-to-check
-                           (pmap (fn [dep] (merge dep {:latest (dep->latest dep)})))
+                           (pmap (fn [dep] (merge dep {:latest (dep->upgrade dep)})))
                            ;; keep if :latest version was found
                            (filter (fn [dep] (some? (:latest dep)))))]
     (when lib

--- a/neil
+++ b/neil
@@ -1406,6 +1406,7 @@ details on the search syntax.")))
 
     (dep->latest-stable {:lib 'hiccup/hiccup
                          :current {:mvn/version \"1.0.4\"}})
+    ;; => {:mvn/version \"1.0.5\"}
   "
   [{:keys [lib current]}]
   ;; for now, just upgrade to stable versions

--- a/neil
+++ b/neil
@@ -1444,12 +1444,7 @@ details on the search syntax.")))
              candidate))
 
          ;; otherwise, do nothing (fall through to nil)
-
-         )
-
-        )
-      #_#_
-      :else (dep->latest-stable {:lib lib :current current}))))
+         )))))
 
 (defn opts->specified-deps
   "Returns all :deps and :alias :extra-deps for the deps.edn indicated by `opts`."

--- a/neil
+++ b/neil
@@ -1423,15 +1423,17 @@ details on the search syntax.")))
       (let [lib (or (git-url->lib (:git/url current))
                     lib)]
         (when-let [tag (git/latest-github-tag lib)]
-          {:git/tag (:name tag)
-           :git/sha (-> tag :commit :sha (subs 0 7))}))
+          (when (not= tag (:git/tag current))
+            {:git/tag (:name tag)
+             :git/sha (-> tag :commit :sha (subs 0 7))})))
 
       ;; if there's a git sha, find the latest git sha.
       (:git/sha current)
       (let [lib (or (git-url->lib (:git/url current))
                     lib)]
         (when-let [sha (git/latest-github-sha lib)]
-          {:git/sha sha}))
+          (when (not= sha (:git/sha current))
+            {:git/sha sha})))
 
       nil nil
       :else (dep->latest-stable {:lib lib :current current}))))

--- a/neil
+++ b/neil
@@ -914,15 +914,6 @@ using the [major|minor|patch] subcommands.
     (empty? (set/intersection (:qualifiers (vparse version-str))
                               #{"rc" "alpha" "beta" "snapshot" "milestone"}))))
 
-(comment
-  (stable-version? "1.0.4")
-  ;; => true
-  (stable-version? "1.0.5")
-  ;; => true
-  (stable-version? "2.0.0-RC1")
-  ;; => false
-  )
-
 (defn first-stable-version [versions]
   (some (fn [version]
           (when (stable-version? version)

--- a/neil
+++ b/neil
@@ -1413,11 +1413,28 @@ details on the search syntax.")))
     (dep->upgrade {:lib 'clj-kondo/clj-kondo :current {:git/sha \"247e538\"}})
     ;; => {:git/sha \"...\"}
   "
-  [{:keys [lib current]}]
+  [{:keys [lib current] :as dep}]
   ;; for now, just upgrade to stable versions
-  (cond
-    nil nil
-    :else (dep->latest-stable {:lib lib :current current})))
+  (let [current (set/rename-keys current {:sha :git/sha
+                                          :tag :git/tag})]
+    (cond
+      ;; if there's a git tag, find the latest git tag.
+      (:git/tag current)
+      (let [lib (or (git-url->lib (:git/url current))
+                    lib)]
+        (when-let [tag (git/latest-github-tag lib)]
+          {:git/tag (:name tag)
+           :git/sha (-> tag :commit :sha (subs 0 7))}))
+
+      ;; if there's a git sha, find the latest git sha.
+      (:git/sha current)
+      (let [lib (or (git-url->lib (:git/url current))
+                    lib)]
+        (when-let [sha (git/latest-github-sha lib)]
+          {:git/sha sha}))
+
+      nil nil
+      :else (dep->latest-stable {:lib lib :current current}))))
 
 (defn opts->specified-deps
   "Returns all :deps and :alias :extra-deps for the deps.edn indicated by `opts`."

--- a/neil
+++ b/neil
@@ -1375,31 +1375,6 @@ details on the search syntax.")))
       (-> (str/replace git-url "https://github.com/" "")
           symbol))))
 
-(defn- dep->latest-stable
-  [{:keys [current lib] :as _dep-update}]
-  (let [v-older? (req-resolve 'version-clj.core/older?)] ; We lazy-load version-clj to improve average script startup time
-    (cond
-      (or (:git/tag current) (:tag current))
-      (let [lib (or (git-url->lib (:git/url current))
-                    lib)]
-        (when-let [tag (git/latest-github-tag lib)]
-          (when tag
-            {:git/tag (:name tag)
-             :git/sha (-> tag :commit :sha (subs 0 7))})))
-
-      (or (:git/sha current) (:sha current))
-      (let [lib (or (git-url->lib (:git/url current))
-                    lib)]
-        (when-let [sha (git/latest-github-sha lib)]
-          {:git/sha sha}))
-
-      (:mvn/version current)
-      (when-let [version (or (first-stable-version (clojars-versions lib {:limit 100}))
-                             (first-stable-version (mvn-versions lib {:limit 100})))]
-        ;; if current version is newer than latest stable release, leave it
-        (when (v-older? (:mvn/version current) version)
-          {:mvn/version version})))))
-
 (defn dep->upgrade
   "Given a lib (hiccup/hiccup) and a version ({:mvn/version \"1.0.4\"}), return an
   upgrade ({:mvn/version \"1.0.5\"}), otherwise return nil.
@@ -1435,7 +1410,45 @@ details on the search syntax.")))
           (when (not= sha (:git/sha current))
             {:git/sha sha})))
 
-      nil nil
+      ;; if `current` is a stable maven/clojars version, find the latest stable
+      ;; maven clojars dep
+      (and (:mvn/version current) (stable-version? (:mvn/version current)))
+      (when-let [version (or (first-stable-version (clojars-versions lib {:limit 100}))
+                             (first-stable-version (mvn-versions lib {:limit 100})))]
+        ;; only upgrade to a newer version than the current. Useful when
+        ;; developing a new version locally.
+        (let [v-older? (req-resolve 'version-clj.core/older?)]
+          (when (v-older? (:mvn/version current) version)
+            {:mvn/version version})))
+
+      ;; if `current` is an unstable maven/clojars version, preferrably upgrade
+      ;; to a more recent stable version. Otherwise, look for a more recent
+      ;; unstable version.
+      ;;
+      ;; Useful when depending on an unstable version under active development.
+      (and (:mvn/version current)
+           (not (stable-version? (:mvn/version current))))
+      (let [clojars-candidates (clojars-versions lib {:limit 100})
+            maven-candidates (mvn-versions lib {:limit 100})
+            v-older? (req-resolve 'version-clj.core/older?)]
+        (or
+         ;; prefer a more recent stable
+         (let [candidate (or (first (filter stable-version? clojars-candidates))
+                             (first (filter stable-version? maven-candidates)))]
+           (when (v-older? (:mvn/version current) candidate)
+             {:mvn/version candidate}))
+
+         ;; otherwise, provide a more recent unstable
+         (let [candidate (or (first clojars-candidates) (first maven-candidates))]
+           (when (v-older? (:mvn/version current) candidate)
+             candidate))
+
+         ;; otherwise, do nothing (fall through to nil)
+
+         )
+
+        )
+      #_#_
       :else (dep->latest-stable {:lib lib :current current}))))
 
 (defn opts->specified-deps

--- a/neil
+++ b/neil
@@ -1419,7 +1419,9 @@ details on the search syntax.")))
   "
   [{:keys [lib current]}]
   ;; for now, just upgrade to stable versions
-  (dep->latest-stable {:lib lib :current current}))
+  (cond
+    nil nil
+    :else (dep->latest-stable {:lib lib :current current})))
 
 (defn opts->specified-deps
   "Returns all :deps and :alias :extra-deps for the deps.edn indicated by `opts`."
@@ -1620,8 +1622,6 @@ test
 
 (defn neil-test [{:keys [opts]}]
   (neil-test/neil-test opts))
-
-
 
 (defn -main [& _args]
   (cli/dispatch

--- a/neil
+++ b/neil
@@ -1404,9 +1404,14 @@ details on the search syntax.")))
   "Given a lib (hiccup/hiccup) and a version ({:mvn/version \"1.0.4\"}), return an
   upgrade ({:mvn/version \"1.0.5\"}), otherwise return nil.
 
+  Supports different kinds of coordinate formats.
+
     (dep->latest-stable {:lib 'hiccup/hiccup
                          :current {:mvn/version \"1.0.4\"}})
     ;; => {:mvn/version \"1.0.5\"}
+
+    (dep->upgrade {:lib 'clj-kondo/clj-kondo :current {:git/sha \"247e538\"}})
+    ;; => {:git/sha \"...\"}
   "
   [{:keys [lib current]}]
   ;; for now, just upgrade to stable versions

--- a/neil
+++ b/neil
@@ -915,10 +915,9 @@ using the [major|minor|patch] subcommands.
                               #{"rc" "alpha" "beta" "snapshot" "milestone"}))))
 
 (defn first-stable-version [versions]
-  (some (fn [version]
-          (when (stable-version? version)
-            version))
-        versions))
+  (->> versions
+       (filter stable-version?)
+       first))
 
 (defn clojars-versions [qlib {:keys [limit] :or {limit 10}}]
   (let [body (get-clojars-artifact qlib)]

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -555,8 +555,8 @@ details on the search syntax.")))
       ;; if `current` is a stable maven/clojars version, find the latest stable
       ;; maven clojars dep
       (and (:mvn/version current) (stable-version? (:mvn/version current)))
-      (when-let [version (or (first-stable-version (clojars-versions lib {:limit 100}))
-                             (first-stable-version (mvn-versions lib {:limit 100})))]
+      (when-let [version (or (first (filter stable-version? (clojars-versions lib {:limit 100})))
+                             (first (filter stable-version? (mvn-versions lib {:limit 100}))))]
         ;; only upgrade to a newer version than the current. Useful when
         ;; developing a new version locally.
         (let [v-older? (req-resolve 'version-clj.core/older?)]

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -548,6 +548,7 @@ details on the search syntax.")))
 
     (dep->latest-stable {:lib 'hiccup/hiccup
                          :current {:mvn/version \"1.0.4\"}})
+    ;; => {:mvn/version \"1.0.5\"}
   "
   [{:keys [lib current]}]
   ;; for now, just upgrade to stable versions

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -765,8 +765,6 @@ test
 (defn neil-test [{:keys [opts]}]
   (neil-test/neil-test opts))
 
-
-
 (defn -main [& _args]
   (cli/dispatch
    [{:cmds ["add" "dep"] :fn dep-add :args->opts [:lib]}

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -549,6 +549,17 @@ details on the search syntax.")))
         (when (v-older? (:mvn/version current) version)
           {:mvn/version version})))))
 
+(defn dep->upgrade
+  "Given a lib (hiccup/hiccup) and a version ({:mvn/version \"1.0.4\"}), return an
+  upgrade ({:mvn/version \"1.0.5\"}), otherwise return nil.
+
+    (dep->latest-stable {:lib 'hiccup/hiccup
+                         :current {:mvn/version \"1.0.4\"}})
+  "
+  [{:keys [lib current]}]
+  ;; for now, just upgrade to stable versions
+  (dep->latest-stable {:lib lib :current current}))
+
 (defn opts->specified-deps
   "Returns all :deps and :alias :extra-deps for the deps.edn indicated by `opts`."
   [opts]

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -13,7 +13,8 @@
    [babashka.neil.version :as neil-version]
    [borkdude.rewrite-edn :as r]
    [clojure.edn :as edn]
-   [clojure.string :as str]))
+   [clojure.string :as str]
+   [clojure.set :as set]))
 
 (def spec {:lib {:desc "Fully qualified library name."}
            :version {:desc "Optional. When not provided, picks newest version from Clojars or Maven Central."
@@ -65,14 +66,10 @@
 
  )
 (defn first-stable-version [versions]
-  (let [vparse (req-resolve 'version-clj.core/parse)]
-    (some (fn [version]
-            (let [{:keys [qualifiers]} (vparse version)]
-              (when-not
-                  ;; assume all qualifiers indicate non-stable version
-                  (some #{"rc" "alpha" "beta" "snapshot" "milestone"} qualifiers)
-                version)))
-          versions)))
+  (some (fn [version]
+          (when (stable-version? version)
+            version))
+        versions))
 
 (defn clojars-versions [qlib {:keys [limit] :or {limit 10}}]
   (let [body (get-clojars-artifact qlib)]

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -56,15 +56,6 @@
     (empty? (set/intersection (:qualifiers (vparse version-str))
                               #{"rc" "alpha" "beta" "snapshot" "milestone"}))))
 
-(comment
-  (stable-version? "1.0.4")
-  ;; => true
-  (stable-version? "1.0.5")
-  ;; => true
-  (stable-version? "2.0.0-RC1")
-  ;; => false
-  )
-
 (defn first-stable-version [versions]
   (some (fn [version]
           (when (stable-version? version)

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -530,7 +530,7 @@ details on the search syntax.")))
     (dep->upgrade {:lib 'clj-kondo/clj-kondo :current {:git/sha \"247e538\"}})
     ;; => {:git/sha \"...\"}
   "
-  [{:keys [lib current] :as dep}]
+  [{:keys [lib current]}]
   ;; for now, just upgrade to stable versions
   (let [current (set/rename-keys current {:sha :git/sha
                                           :tag :git/tag})]

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -565,15 +565,17 @@ details on the search syntax.")))
       (let [lib (or (git-url->lib (:git/url current))
                     lib)]
         (when-let [tag (git/latest-github-tag lib)]
-          {:git/tag (:name tag)
-           :git/sha (-> tag :commit :sha (subs 0 7))}))
+          (when (not= tag (:git/tag current))
+            {:git/tag (:name tag)
+             :git/sha (-> tag :commit :sha (subs 0 7))})))
 
       ;; if there's a git sha, find the latest git sha.
       (:git/sha current)
       (let [lib (or (git-url->lib (:git/url current))
                     lib)]
         (when-let [sha (git/latest-github-sha lib)]
-          {:git/sha sha}))
+          (when (not= sha (:git/sha current))
+            {:git/sha sha})))
 
       nil nil
       :else (dep->latest-stable {:lib lib :current current}))))

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -63,8 +63,8 @@
   ;; => true
   (stable-version? "2.0.0-RC1")
   ;; => false
+  )
 
- )
 (defn first-stable-version [versions]
   (some (fn [version]
           (when (stable-version? version)

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -57,10 +57,9 @@
                               #{"rc" "alpha" "beta" "snapshot" "milestone"}))))
 
 (defn first-stable-version [versions]
-  (some (fn [version]
-          (when (stable-version? version)
-            version))
-        versions))
+  (->> versions
+       (filter stable-version?)
+       first))
 
 (defn clojars-versions [qlib {:keys [limit] :or {limit 10}}]
   (let [body (get-clojars-artifact qlib)]

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -586,12 +586,7 @@ details on the search syntax.")))
              candidate))
 
          ;; otherwise, do nothing (fall through to nil)
-
-         )
-
-        )
-      #_#_
-      :else (dep->latest-stable {:lib lib :current current}))))
+         )))))
 
 (defn opts->specified-deps
   "Returns all :deps and :alias :extra-deps for the deps.edn indicated by `opts`."

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -515,7 +515,7 @@ details on the search syntax.")))
       (-> (str/replace git-url "https://github.com/" "")
           symbol))))
 
-(defn dep->latest
+(defn dep->latest-stable
   "Expects a `dep-upgrade` map, with `:lib` and `:current` keys.
   `:current` is the dep's current coordinates, like `{:mvn/version \"some-version\"}`
   or `{:git/sha \"sha-blah\"}`.
@@ -628,7 +628,7 @@ Examples:
         alias         (some-> opts :alias)
         deps-to-check (opts->specified-deps opts)
         upgrades      (->> deps-to-check
-                           (pmap (fn [dep] (merge dep {:latest (dep->latest dep)})))
+                           (pmap (fn [dep] (merge dep {:latest (dep->latest-stable dep)})))
                            ;; keep if :latest version was found
                            (filter (fn [dep] (some? (:latest dep)))))]
     (when lib

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -546,9 +546,14 @@ details on the search syntax.")))
   "Given a lib (hiccup/hiccup) and a version ({:mvn/version \"1.0.4\"}), return an
   upgrade ({:mvn/version \"1.0.5\"}), otherwise return nil.
 
+  Supports different kinds of coordinate formats.
+
     (dep->latest-stable {:lib 'hiccup/hiccup
                          :current {:mvn/version \"1.0.4\"}})
     ;; => {:mvn/version \"1.0.5\"}
+
+    (dep->upgrade {:lib 'clj-kondo/clj-kondo :current {:git/sha \"247e538\"}})
+    ;; => {:git/sha \"...\"}
   "
   [{:keys [lib current]}]
   ;; for now, just upgrade to stable versions

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -49,6 +49,21 @@
    (format "https://clojars.org/api/artifacts/%s"
            qlib)))
 
+(defn stable-version?
+  [version-str]
+  (let [vparse (req-resolve 'version-clj.core/parse)]
+    (empty? (set/intersection (:qualifiers (vparse version-str))
+                              #{"rc" "alpha" "beta" "snapshot" "milestone"}))))
+
+(comment
+  (stable-version? "1.0.4")
+  ;; => true
+  (stable-version? "1.0.5")
+  ;; => true
+  (stable-version? "2.0.0-RC1")
+  ;; => false
+
+ )
 (defn first-stable-version [versions]
   (let [vparse (req-resolve 'version-clj.core/parse)]
     (some (fn [version]

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -520,7 +520,9 @@ details on the search syntax.")))
   `:current` is the dep's current coordinates, like `{:mvn/version \"some-version\"}`
   or `{:git/sha \"sha-blah\"}`.
 
-  Returns a `latest` coordinate as a map with `:mvn/version` or `:git/sha`.
+  Returns a `latest` coordinate as a map with `:mvn/version` or `:git/sha` if a
+  valid upgrade is found, `nil` otherwise.
+
   Note that this is not a full dep coordinate - we rely on `dep-add` later to include
   `:git/url`, for example."
   [{:keys [current lib] :as _dep-update}]

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -52,7 +52,7 @@
 
 (defn stable-version?
   [version-str]
-  (let [vparse (req-resolve 'version-clj.core/parse)]
+  (let [vparse (req-resolve 'version-clj.core/parse)] ; We lazy-load version-clj to improve average script startup time
     (empty? (set/intersection (:qualifiers (vparse version-str))
                               #{"rc" "alpha" "beta" "snapshot" "milestone"}))))
 
@@ -529,7 +529,7 @@ details on the search syntax.")))
 
 (defn- dep->latest-stable
   [{:keys [current lib] :as _dep-update}]
-  (let [v-older? (req-resolve 'version-clj.core/older?)]
+  (let [v-older? (req-resolve 'version-clj.core/older?)] ; We lazy-load version-clj to improve average script startup time
     (cond
       (or (:git/tag current) (:tag current))
       (let [lib (or (git-url->lib (:git/url current))

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -555,11 +555,28 @@ details on the search syntax.")))
     (dep->upgrade {:lib 'clj-kondo/clj-kondo :current {:git/sha \"247e538\"}})
     ;; => {:git/sha \"...\"}
   "
-  [{:keys [lib current]}]
+  [{:keys [lib current] :as dep}]
   ;; for now, just upgrade to stable versions
-  (cond
-    nil nil
-    :else (dep->latest-stable {:lib lib :current current})))
+  (let [current (set/rename-keys current {:sha :git/sha
+                                          :tag :git/tag})]
+    (cond
+      ;; if there's a git tag, find the latest git tag.
+      (:git/tag current)
+      (let [lib (or (git-url->lib (:git/url current))
+                    lib)]
+        (when-let [tag (git/latest-github-tag lib)]
+          {:git/tag (:name tag)
+           :git/sha (-> tag :commit :sha (subs 0 7))}))
+
+      ;; if there's a git sha, find the latest git sha.
+      (:git/sha current)
+      (let [lib (or (git-url->lib (:git/url current))
+                    lib)]
+        (when-let [sha (git/latest-github-sha lib)]
+          {:git/sha sha}))
+
+      nil nil
+      :else (dep->latest-stable {:lib lib :current current}))))
 
 (defn opts->specified-deps
   "Returns all :deps and :alias :extra-deps for the deps.edn indicated by `opts`."

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -639,7 +639,7 @@ Examples:
         alias         (some-> opts :alias)
         deps-to-check (opts->specified-deps opts)
         upgrades      (->> deps-to-check
-                           (pmap (fn [dep] (merge dep {:latest (dep->latest-stable dep)})))
+                           (pmap (fn [dep] (merge dep {:latest (dep->upgrade dep)})))
                            ;; keep if :latest version was found
                            (filter (fn [dep] (some? (:latest dep)))))]
     (when lib

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -527,16 +527,7 @@ details on the search syntax.")))
       (-> (str/replace git-url "https://github.com/" "")
           symbol))))
 
-(defn dep->latest-stable
-  "Expects a `dep-upgrade` map, with `:lib` and `:current` keys.
-  `:current` is the dep's current coordinates, like `{:mvn/version \"some-version\"}`
-  or `{:git/sha \"sha-blah\"}`.
-
-  Returns a `latest` coordinate as a map with `:mvn/version` or `:git/sha` if a
-  valid upgrade is found, `nil` otherwise.
-
-  Note that this is not a full dep coordinate - we rely on `dep-add` later to include
-  `:git/url`, for example."
+(defn- dep->latest-stable
   [{:keys [current lib] :as _dep-update}]
   (let [v-older? (req-resolve 'version-clj.core/older?)]
     (cond

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -561,7 +561,9 @@ details on the search syntax.")))
   "
   [{:keys [lib current]}]
   ;; for now, just upgrade to stable versions
-  (dep->latest-stable {:lib lib :current current}))
+  (cond
+    nil nil
+    :else (dep->latest-stable {:lib lib :current current})))
 
 (defn opts->specified-deps
   "Returns all :deps and :alias :extra-deps for the deps.edn indicated by `opts`."

--- a/test/babashka/neil/dep_upgrade_test.clj
+++ b/test/babashka/neil/dep_upgrade_test.clj
@@ -203,7 +203,6 @@
          (neil/dep->latest {:lib 'com.grzm/awyeah-api
                             :current {:git/url "https://github.com/grzm/awyeah-api"
                                       :git/sha "1810bf6"
-                                      :git/tag "v0.8.35"}
-                            :mvn/version "2.0.0-alpha2"})))
+                                      :git/tag "v0.8.35"}})))
   (is (some? (neil/dep->latest {:lib 'com.google.apis/google-api-services-sheets
                                 :current {:mvn/version "v4-rev20220927-2.0.0"}}))))

--- a/test/babashka/neil/dep_upgrade_test.clj
+++ b/test/babashka/neil/dep_upgrade_test.clj
@@ -190,12 +190,15 @@
 
 (deftest prefer-stable-version-test
   (is (nil? (neil/dep->latest {:lib 'hiccup/hiccup
-                               :current {:mvn/version "1.0.5"}})))
+                               :current {:mvn/version "1.0.5"}}))
+      "1.0.5 is (per 2023-07-10) the latest stable version of hiccup, no updates are available")
   (is (= #:mvn{:version "1.0.5"}
          (neil/dep->latest {:lib 'hiccup/hiccup
-                            :current {:mvn/version "1.0.4"}})))
+                            :current {:mvn/version "1.0.4"}}))
+      "1.0.5 is an update to 1.0.4 for hiccup")
   (is (nil? (neil/dep->latest {:lib 'hiccup/hiccup
-                               :current {:mvn/version "2.0.0-alpha2"}})))
+                               :current {:mvn/version "2.0.0-alpha2"}}))
+      "Neil does not propose updates to unstable versions")
   (is (= #:git{:tag "v0.8.41", :sha "9257dc0"}
          (neil/dep->latest {:lib 'com.grzm/awyeah-api
                             :current {:git/url "https://github.com/grzm/awyeah-api"

--- a/test/babashka/neil/dep_upgrade_test.clj
+++ b/test/babashka/neil/dep_upgrade_test.clj
@@ -189,13 +189,18 @@
         (is (not (= initial-clj-kondo-v upgraded-clj-kondo-v)))))))
 
 (deftest prefer-stable-version-test
-  (is (nil? (neil/dep->latest {:lib 'hiccup/hiccup :current {:mvn/version "1.0.5"}})))
-  (is (= #:mvn{:version "1.0.5"} (neil/dep->latest {:lib 'hiccup/hiccup :current {:mvn/version "1.0.4"}})))
-  (is (nil? (neil/dep->latest {:lib 'hiccup/hiccup :current {:mvn/version "2.0.0-alpha2"}})))
+  (is (nil? (neil/dep->latest {:lib 'hiccup/hiccup
+                               :current {:mvn/version "1.0.5"}})))
+  (is (= #:mvn{:version "1.0.5"}
+         (neil/dep->latest {:lib 'hiccup/hiccup
+                            :current {:mvn/version "1.0.4"}})))
+  (is (nil? (neil/dep->latest {:lib 'hiccup/hiccup
+                               :current {:mvn/version "2.0.0-alpha2"}})))
   (is (= #:git{:tag "v0.8.41", :sha "9257dc0"}
          (neil/dep->latest {:lib 'com.grzm/awyeah-api
                             :current {:git/url "https://github.com/grzm/awyeah-api"
                                       :git/sha "1810bf6"
-                                      :git/tag "v0.8.35"}:mvn/version "2.0.0-alpha2"})))
+                                      :git/tag "v0.8.35"}
+                            :mvn/version "2.0.0-alpha2"})))
   (is (some? (neil/dep->latest {:lib 'com.google.apis/google-api-services-sheets
                                 :current {:mvn/version "v4-rev20220927-2.0.0"}}))))

--- a/test/babashka/neil/dep_upgrade_test.clj
+++ b/test/babashka/neil/dep_upgrade_test.clj
@@ -218,3 +218,11 @@
                                             :current {:git/sha "247e538"}})]
       (is (:git/sha kondo-upgrade) "a tag is returned.")
       (is (not (:git/tag kondo-upgrade)) ", there is no tag."))))
+
+(deftest stable-version-test
+  (let [stable true
+        unstable false]
+    (are [stability version-str] (= stability (neil/stable-version? version-str))
+      stable "1.0.4"
+      stable "1.0.5"
+      unstable "2.0.0-RC1")))

--- a/test/babashka/neil/dep_upgrade_test.clj
+++ b/test/babashka/neil/dep_upgrade_test.clj
@@ -189,20 +189,20 @@
         (is (not (= initial-clj-kondo-v upgraded-clj-kondo-v)))))))
 
 (deftest prefer-stable-version-test
-  (is (nil? (neil/dep->latest {:lib 'hiccup/hiccup
-                               :current {:mvn/version "1.0.5"}}))
+  (is (nil? (neil/dep->latest-stable {:lib 'hiccup/hiccup
+                                      :current {:mvn/version "1.0.5"}}))
       "1.0.5 is (per 2023-07-10) the latest stable version of hiccup, no updates are available")
   (is (= #:mvn{:version "1.0.5"}
-         (neil/dep->latest {:lib 'hiccup/hiccup
-                            :current {:mvn/version "1.0.4"}}))
+         (neil/dep->latest-stable {:lib 'hiccup/hiccup
+                                   :current {:mvn/version "1.0.4"}}))
       "1.0.5 is an update to 1.0.4 for hiccup")
-  (is (nil? (neil/dep->latest {:lib 'hiccup/hiccup
-                               :current {:mvn/version "2.0.0-alpha2"}}))
+  (is (nil? (neil/dep->latest-stable {:lib 'hiccup/hiccup
+                                      :current {:mvn/version "2.0.0-alpha2"}}))
       "Neil does not propose updates to unstable versions")
   (is (= #:git{:tag "v0.8.41", :sha "9257dc0"}
-         (neil/dep->latest {:lib 'com.grzm/awyeah-api
-                            :current {:git/url "https://github.com/grzm/awyeah-api"
-                                      :git/sha "1810bf6"
-                                      :git/tag "v0.8.35"}})))
-  (is (some? (neil/dep->latest {:lib 'com.google.apis/google-api-services-sheets
-                                :current {:mvn/version "v4-rev20220927-2.0.0"}}))))
+         (neil/dep->latest-stable {:lib 'com.grzm/awyeah-api
+                                   :current {:git/url "https://github.com/grzm/awyeah-api"
+                                             :git/sha "1810bf6"
+                                             :git/tag "v0.8.35"}})))
+  (is (some? (neil/dep->latest-stable {:lib 'com.google.apis/google-api-services-sheets
+                                       :current {:mvn/version "v4-rev20220927-2.0.0"}}))))

--- a/test/babashka/neil/dep_upgrade_test.clj
+++ b/test/babashka/neil/dep_upgrade_test.clj
@@ -188,22 +188,12 @@
         (is (= initial-fs-v upgraded-fs-v))
         (is (not (= initial-clj-kondo-v upgraded-clj-kondo-v)))))))
 
-(deftest prefer-stable-version-test
-  (is (nil? (neil/dep->upgrade {:lib 'hiccup/hiccup
-                                :current {:mvn/version "1.0.5"}}))
-      "1.0.5 is (per 2023-07-10) the latest stable version of hiccup, no updates are available")
-  (is (= #:mvn{:version "1.0.5"}
-         (neil/dep->upgrade {:lib 'hiccup/hiccup
-                             :current {:mvn/version "1.0.4"}}))
-      "1.0.5 is an update to 1.0.4 for hiccup")
-  (is (nil? (neil/dep->upgrade {:lib 'hiccup/hiccup
-                                :current {:mvn/version "2.0.0-alpha2"}}))
-      "Neil does not propose updates to unstable versions")
-  (is (= #:git{:tag "v0.8.41", :sha "9257dc0"}
-         (neil/dep->upgrade {:lib 'com.grzm/awyeah-api
-                             :current {:git/url "https://github.com/grzm/awyeah-api"
-                                       :git/sha "1810bf6"
-                                       :git/tag "v0.8.35"}})))
+(deftest prefer-stable-test
+  (are [upgrade dep] (= upgrade (neil/dep->upgrade dep))
+    nil                    {:lib 'hiccup/hiccup :current {:mvn/version "1.0.5"}}
+    {:mvn/version "1.0.5"} {:lib 'hiccup/hiccup :current {:mvn/version "1.0.4"}}
+    nil                    {:mvn/version "2.0.0-alpha2"})
+
   (is (some? (neil/dep->upgrade {:lib 'com.google.apis/google-api-services-sheets
                                  :current {:mvn/version "v4-rev20220927-2.0.0"}}))))
 

--- a/test/babashka/neil/dep_upgrade_test.clj
+++ b/test/babashka/neil/dep_upgrade_test.clj
@@ -203,3 +203,18 @@
     ["2.0.0-RC1"] nil
     ["1.0.4" "2.0.0-RC1"] "1.0.4"
     ["2.0.0-RC1" "1.0.4"] "1.0.4"))
+
+(deftest dep->upgrade-test
+  (testing "when a tag is provided,"
+    (let [kondo-upgrade (neil/dep->upgrade {:lib 'clj-kondo/clj-kondo
+                                            :current {:git/url "https://github.com/clj-kondo/clj-kondo",
+                                                      :git/tag "v2022.03.08",
+                                                      :git/sha "247e538"}})]
+      (is (:git/tag kondo-upgrade) "a tag is returned.")
+      (is (:git/sha kondo-upgrade) "a sha is also returned")))
+
+  (testing "when only a sha is provided,"
+    (let [kondo-upgrade (neil/dep->upgrade {:lib 'clj-kondo/clj-kondo
+                                            :current {:git/sha "247e538"}})]
+      (is (:git/sha kondo-upgrade) "a tag is returned.")
+      (is (not (:git/tag kondo-upgrade)) ", there is no tag."))))

--- a/test/babashka/neil/dep_upgrade_test.clj
+++ b/test/babashka/neil/dep_upgrade_test.clj
@@ -189,20 +189,20 @@
         (is (not (= initial-clj-kondo-v upgraded-clj-kondo-v)))))))
 
 (deftest prefer-stable-version-test
-  (is (nil? (neil/dep->latest-stable {:lib 'hiccup/hiccup
-                                      :current {:mvn/version "1.0.5"}}))
+  (is (nil? (neil/dep->upgrade {:lib 'hiccup/hiccup
+                                :current {:mvn/version "1.0.5"}}))
       "1.0.5 is (per 2023-07-10) the latest stable version of hiccup, no updates are available")
   (is (= #:mvn{:version "1.0.5"}
-         (neil/dep->latest-stable {:lib 'hiccup/hiccup
-                                   :current {:mvn/version "1.0.4"}}))
+         (neil/dep->upgrade {:lib 'hiccup/hiccup
+                             :current {:mvn/version "1.0.4"}}))
       "1.0.5 is an update to 1.0.4 for hiccup")
-  (is (nil? (neil/dep->latest-stable {:lib 'hiccup/hiccup
-                                      :current {:mvn/version "2.0.0-alpha2"}}))
+  (is (nil? (neil/dep->upgrade {:lib 'hiccup/hiccup
+                                :current {:mvn/version "2.0.0-alpha2"}}))
       "Neil does not propose updates to unstable versions")
   (is (= #:git{:tag "v0.8.41", :sha "9257dc0"}
-         (neil/dep->latest-stable {:lib 'com.grzm/awyeah-api
-                                   :current {:git/url "https://github.com/grzm/awyeah-api"
-                                             :git/sha "1810bf6"
-                                             :git/tag "v0.8.35"}})))
-  (is (some? (neil/dep->latest-stable {:lib 'com.google.apis/google-api-services-sheets
-                                       :current {:mvn/version "v4-rev20220927-2.0.0"}}))))
+         (neil/dep->upgrade {:lib 'com.grzm/awyeah-api
+                             :current {:git/url "https://github.com/grzm/awyeah-api"
+                                       :git/sha "1810bf6"
+                                       :git/tag "v0.8.35"}})))
+  (is (some? (neil/dep->upgrade {:lib 'com.google.apis/google-api-services-sheets
+                                 :current {:mvn/version "v4-rev20220927-2.0.0"}}))))

--- a/test/babashka/neil/dep_upgrade_test.clj
+++ b/test/babashka/neil/dep_upgrade_test.clj
@@ -2,7 +2,7 @@
   (:require
    [babashka.neil :as neil]
    [babashka.neil.test-util :as test-util]
-   [clojure.test :as t :refer [deftest is testing]]
+   [clojure.test :as t :refer [deftest is testing are]]
    [clojure.edn :as edn]
    [clojure.set :as set]))
 
@@ -206,3 +206,10 @@
                                        :git/tag "v0.8.35"}})))
   (is (some? (neil/dep->upgrade {:lib 'com.google.apis/google-api-services-sheets
                                  :current {:mvn/version "v4-rev20220927-2.0.0"}}))))
+
+(deftest first-stable-version-test
+  (are [all-versions first-stable] (= first-stable (neil/first-stable-version all-versions))
+    ["1.0.4"] "1.0.4"
+    ["2.0.0-RC1"] nil
+    ["1.0.4" "2.0.0-RC1"] "1.0.4"
+    ["2.0.0-RC1" "1.0.4"] "1.0.4"))


### PR DESCRIPTION
- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
    - #180 

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/neil/blob/main/CHANGELOG.md) file with a description of the addressed issue.

-----

A fresh take on #179 , moving slower and leaning more heavily on tests for development.

1. Stable versions are only upgraded to more recent stable versions
2. For unstable versions,
    1. A more recent stable version is preferred,
    2. Otherwise, a more recent unstable version is selected.

I added a `:dev` alias to `deps.edn` for working with tests from the REPL. I can remove it if needed.

I also made some changes to existing tests, and added some new one. I think it's easier to understand what the code does from reading the tests now.

-----

For a library with the following available versions: `1.0.1-alpha1`, `1.0.1-alpha2`, `1.0.1`, `1.0.2`, `2.0.0-alpha1`, `2.0.0-alpha2`, before this PR, we would see this behavior:

- `1.0.1-alpha1` is upgraded to `1.0.2`
- `1.0.1` is upgraded to `1.0.2`
- `2.0.0-alpha1` is not upgraded

After this PR, we would see this behavior:

- `1.0.1-alpha1` is upgraded to `1.0.2` (unchanged)
- `1.0.1` is upgraded to `1.0.2` (unchanged)
- `2.0.0-alpha1` is upgraded to `2.0.0-alpha` (new behavior)