### PR TITLE
`neil dep upgrade`: `--unstable` allows upgrades to unstable versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ See the [New Clojure project quickstart](https://blog.michielborkent.nl/new-cloj
 - [#181](https://github.com/babashka/neil/issues/181): fix `neil --version`
 - fix tests by referring to latest hiccup ([@teodorlu](https://github.com/teodorlu))
 - [#180](https://github.com/babashka/neil/issues/180): `neil dep upgrade`: allow upgrading from an unstable version to the latest unstable version ([@teodorlu](https://github.com/teodorlu))
+- [#180](https://github.com/babashka/neil/issues/180): `neil dep upgrade`: with `--unstable`, opt-into unstable library updates ([@teodorlu](https://github.com/teodorlu))
 
 ## 0.1.60 (2023-03-22)
 

--- a/neil
+++ b/neil
@@ -1388,7 +1388,7 @@ details on the search syntax.")))
     (dep->upgrade {:lib 'clj-kondo/clj-kondo :current {:git/sha \"247e538\"}})
     ;; => {:git/sha \"...\"}
   "
-  [{:keys [lib current]}]
+  [{:keys [lib current unstable]}]
   ;; for now, just upgrade to stable versions
   (let [current (set/rename-keys current {:sha :git/sha
                                           :tag :git/tag})]
@@ -1409,6 +1409,14 @@ details on the search syntax.")))
         (when-let [sha (git/latest-github-sha lib)]
           (when (not= sha (:git/sha current))
             {:git/sha sha})))
+
+      ;; when :unstable is set, find the lastest version whatsoever
+      unstable
+      (when-let [version (or (first (clojars-versions lib {:limit 100}))
+                             (first (mvn-versions lib {:limit 100})))]
+        (let [v-older? (req-resolve 'version-clj.core/older?)]
+          (when (v-older? (:mvn/version current) version)
+            {:mvn/version version})))
 
       ;; if `current` is a stable maven/clojars version, find the latest stable
       ;; maven clojars dep
@@ -1455,7 +1463,8 @@ details on the search syntax.")))
         {:keys [deps aliases]} (-> (edn-string opts) edn/read-string)
         current-deps
         (->> deps (map (fn [[lib current]]
-                         {:lib lib :current current})))
+                         (cond-> {:lib lib :current current}
+                           (:unstable opts) (assoc :unstable true)))))
         alias-deps
         (if no-aliases? []
             (->> aliases (mapcat (fn [[alias def]]

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -530,7 +530,7 @@ details on the search syntax.")))
     (dep->upgrade {:lib 'clj-kondo/clj-kondo :current {:git/sha \"247e538\"}})
     ;; => {:git/sha \"...\"}
   "
-  [{:keys [lib current]}]
+  [{:keys [lib current unstable]}]
   ;; for now, just upgrade to stable versions
   (let [current (set/rename-keys current {:sha :git/sha
                                           :tag :git/tag})]
@@ -551,6 +551,14 @@ details on the search syntax.")))
         (when-let [sha (git/latest-github-sha lib)]
           (when (not= sha (:git/sha current))
             {:git/sha sha})))
+
+      ;; when :unstable is set, find the lastest version whatsoever
+      unstable
+      (when-let [version (or (first (clojars-versions lib {:limit 100}))
+                             (first (mvn-versions lib {:limit 100})))]
+        (let [v-older? (req-resolve 'version-clj.core/older?)]
+          (when (v-older? (:mvn/version current) version)
+            {:mvn/version version})))
 
       ;; if `current` is a stable maven/clojars version, find the latest stable
       ;; maven clojars dep

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -605,7 +605,8 @@ details on the search syntax.")))
         {:keys [deps aliases]} (-> (edn-string opts) edn/read-string)
         current-deps
         (->> deps (map (fn [[lib current]]
-                         {:lib lib :current current})))
+                         (cond-> {:lib lib :current current}
+                           (:unstable opts) (assoc :unstable true)))))
         alias-deps
         (if no-aliases? []
             (->> aliases (mapcat (fn [[alias def]]

--- a/test/babashka/neil/dep_upgrade_test.clj
+++ b/test/babashka/neil/dep_upgrade_test.clj
@@ -217,7 +217,13 @@
     (let [kondo-upgrade (neil/dep->upgrade {:lib 'clj-kondo/clj-kondo
                                             :current {:git/sha "247e538"}})]
       (is (:git/sha kondo-upgrade) "a tag is returned.")
-      (is (not (:git/tag kondo-upgrade)) ", there is no tag."))))
+      (is (not (:git/tag kondo-upgrade)) ", there is no tag.")))
+
+  (testing "when --unstable is set, upgrade to unstable hiccup versions"
+    (is (= {:mvn/version "2.0.0-RC1"}
+           (neil/dep->upgrade {:lib 'hiccup/hiccup
+                               :current {:mvn/version "1.0.0"}
+                               :unstable true})))))
 
 (deftest stable-version-test
   (let [stable true


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
    - #180 (continuing by adding an `--unstable` flag)

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/neil/blob/main/CHANGELOG.md) file with a description of the addressed issue.

---

`neil dep upgrade --unstable` will now upggrade to the latest unstable version.