### PR TITLE
Make code snippet executable when using copy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ See the [New Clojure project quickstart](https://blog.michielborkent.nl/new-cloj
 ### Homebrew (Linux and macOS)
 
 ```
-$ brew install babashka/brew/neil
+brew install babashka/brew/neil
 ```
 
 ### Scoop (Windows)


### PR DESCRIPTION
The code snippets have a copy button on the far right side of the 'code area'. But when you paste the copied text into your terminal, the copied text is not executable: it has a dollar sign in the front. On the web page, it signifies the user's prompt, but in the terminal, the shell can't make any chocolate of it ;-)

So in order to facilitate the users that want to copy the code examples into their terminal windows, this PR proposes to remove the leading $-sign in the code snippets. And maybe you know something smart for multi-line snippets as well (rewrite using && perhaps?).

Please answer the following questions and leave the below in as part of your PR.

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/neil/blob/main/CHANGELOG.md) file with a description of the addressed issue.
