### PR TITLE
adds maven for dep search

### DIFF
--- a/.github/workflows/bb-run-tests-emacs.yml
+++ b/.github/workflows/bb-run-tests-emacs.yml
@@ -13,5 +13,21 @@ jobs:
       - name: Install emacs
         uses: purcell/setup-emacs@master
         with:
-          version: 28.1
+          version: 29.1
+
+      - name: install buttercup
+        run: |-
+          set -e
+          script=$(cat <<- 'EOF'
+            (progn
+              (require 'package)
+              (add-to-list 'package-archives '("melpa" . "http://melpa.org/packages/"))
+              (package-initialize)
+              (unless (package-installed-p 'buttercup)
+                (package-refresh-contents)
+                (package-install 'buttercup)))
+          EOF
+          )
+          emacs --batch --eval "$script"
+
       - run: bb run test:emacs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ See the [New Clojure project quickstart](https://blog.michielborkent.nl/new-cloj
 
 ## Unreleased
 
+- [#194](https://github.com/babashka/neil/issues/41): `dep search` in addition to Clojars, now also searches on Maven
+
 - [#92](https://github.com/babashka/neil/issues/180): `neil dep upgrade`: delete rogue "`" character from helptext ([@teodorlu](https://github.com/teodorlu))
 
 ## 0.2.62

--- a/neil-tests.el
+++ b/neil-tests.el
@@ -43,14 +43,14 @@
                ((eq shell-cmd-calls 1)
                 (expect command :to-equal "/bin/neil dep search test-pkg")
                 (concat
-                 ":lib foo/test-pkg :version 1.0.0 :description \"good lib\"\n"
-                 ":lib bar/awesome-test-pkg :version 2.1.0 :description \"better lib\"\n"))
+                 ":lib foo/test-pkg :version \"1.0.0\" :description \"good lib\"\n"
+                 ":lib bar/awesome-test-pkg :version \"2.1.0\" :description \"better lib\"\n"))
 
                ((eq shell-cmd-calls 2)
                  (expect command :to-equal "/bin/neil dep versions foo/test-pkg")
                  (concat
-                  ":lib foo/test-pkg :version 1.0.0\n"
-                  ":lib bar/awesome-test-pkg :version 2.1.0\n")))))
+                  ":lib foo/test-pkg :version \"1.0.0\"\n"
+                  ":lib bar/awesome-test-pkg :version \"2.1.0\"\n")))))
     (spy-on #'neil-search-annotation-fn)
     (spy-on #'completing-read
             :and-call-fake
@@ -64,8 +64,12 @@
                ((eq prompt-calls 1)
                 (expect prompt :to-equal "Found 2 matches for 'test-pkg':")
                 (expect coll :to-equal
-                        '(("foo/test-pkg" (version . "1.0.0") (description . "\"good lib\""))
-                          ("bar/awesome-test-pkg" (version . "2.1.0") (description . "\"better lib\""))))
+                        '(("foo/test-pkg"
+                           (version . "\"1.0.0\"")
+                           (description . "\"good lib\""))
+                          ("bar/awesome-test-pkg"
+                           (version . "\"2.1.0\"")
+                           (description . "\"better lib\""))))
                 "foo/test-pkg")
 
                ((eq prompt-calls 2)

--- a/neil.el
+++ b/neil.el
@@ -85,7 +85,7 @@ the dependency to the project (deps.edn only)."
           (lambda (exe args)
             (let* ((res (shell-command-to-string
                          (format "%s %s" exe args)))
-                   (res (if (or (string-match-p "Error" res)
+                   (res (if (or (string-match-p "Error\\|Usage: neil dep search" res)
                                 (and (string-match-p "Unable to find.*Maven" res)
                                      (string-match-p "Unable to find.*Clojars" res)))
                             (user-error res)

--- a/neil.el
+++ b/neil.el
@@ -77,8 +77,8 @@ the dependency to the project (deps.edn only)."
               (when (and lib-name version)
                 (if (or (null build-tool)
                         (eq build-tool 'clojure-cli))
-                    (format "%s {:mvn/version %S}" lib-name version)
-                  (format "[%s %S]" lib-name version))))))
+                    (format "%s {:mvn/version %s}" lib-name version)
+                  (format "[%s %s]" lib-name version))))))
 
          (perform-action
           (lambda (exe args)

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -502,7 +502,7 @@ details on the search syntax.")))
 
 (defn dep-search-maven [search-term]
   (let [url (format
-             "https://search.maven.org/solrsearch/select?q=a:%s&rows=20&wt=json"
+             "https://search.maven.org/solrsearch/select?q=%s&rows=20&wt=json"
              (url-encode search-term))
         keys-m {:g :group_name
                 :a :jar_name
@@ -514,12 +514,13 @@ details on the search syntax.")))
                    (assoc
                     m :description
                     (format "%s/%s on Maven" group_name jar_name)))
-        res (some-> url curl-get-json :response :docs
-                    first
-                    (clojure.set/rename-keys keys-m)
-                    (select-keys (vals keys-m))
-                    add-desc vector)]
-    (if (nil? res)
+        res (->> url curl-get-json :response :docs
+                    (map #(some->
+                           %
+                           (clojure.set/rename-keys keys-m)
+                           (select-keys (vals keys-m))
+                           add-desc)))]
+    (if (empty? res)
       (binding [*out* *err*]
         (println "Unable to find" search-term "on Maven."))
       res)))

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -508,13 +508,17 @@ details on the search syntax.")))
                 :a :jar_name
                 :timestamp :created
                 :latestVersion :version}
+        add-desc (fn [{:keys [group_name jar_name] :as m}]
+                   ;; Maven doesn't provide package description through its API,
+                   ;; but that doesn't mean we should just leave it blank
+                   (assoc
+                    m :description
+                    (format "%s/%s on Maven" group_name jar_name)))
         res (some-> url curl-get-json :response :docs
                     first
                     (clojure.set/rename-keys keys-m)
                     (select-keys (vals keys-m))
-                    ;; maven doesn't provide description through its API
-                    (as-> m (assoc m :description (str (:group_name m) " on Maven")))
-                    vector)]
+                    add-desc vector)]
     (if (nil? res)
       (binding [*out* *err*]
         (println "Unable to find" search-term "on Maven."))

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -537,19 +537,21 @@ details on the search syntax.")))
       search-results)))
 
 (defn dep-search [{:keys [opts]}]
-  (if (or (:help opts) (not (:search-term opts)))
-    (print-dep-search-help)
-    (let [search-term (:search-term opts)
-          search-results (->> [dep-search-maven
-                               dep-search-clojars]
-                              (map #(% search-term))
-                              (apply concat))]
-      (when (empty? search-results) (System/exit 1))
-      (doseq [search-result search-results]
-        (prn :lib (symbol (:group_name search-result)
-                          (:jar_name search-result))
-             :version (:version search-result)
-             :description (:description search-result))))))
+  (let [{:keys [search-term]} opts]
+    (if (or (:help opts)
+            (not (string? search-term))
+            (str/blank? search-term))
+      (print-dep-search-help)
+      (let [search-results (->> [dep-search-maven
+                                 dep-search-clojars]
+                                (map #(% search-term))
+                                (apply concat))]
+        (when (empty? search-results) (System/exit 1))
+        (doseq [search-result search-results]
+          (prn :lib (symbol (:group_name search-result)
+                            (:jar_name search-result))
+               :version (:version search-result)
+               :description (:description search-result)))))))
 
 (defn git-url->lib [git-url]
   (when git-url

--- a/tests.clj
+++ b/tests.clj
@@ -88,7 +88,21 @@
   #_(is (any? (run-dep-subcommand "search" "org.clojure/tools.cli")))
   (is (any? (run-dep-subcommand "search" "babashka nrepl")))
   (is (thrown-with-msg? Exception #"Unable to find"
-        (run-dep-subcommand "search" "%22searchTermThatIsn'tFound"))))
+                        (run-dep-subcommand "search" "%22searchTermThatIsn'tFound")))
+  (is (some #(str/starts-with? % "Usage: neil dep search")
+            (run-dep-subcommand "search" "42"))
+      "passing non-string shows help")
+  (is (some #(str/starts-with? % "Usage: neil dep search")
+            (run-dep-subcommand "search" "  "))
+      "passing blank string shows help")
+  (is (some
+       (partial
+        re-matches
+        (re-pattern
+         (str ":lib org.clojure/clojurescript "
+              ":version \"\\d+(\\.\\d+)+\" "
+              ":description \"org.clojure/clojurescript on Maven\"")))
+       (run-dep-subcommand "search" "\"org.clojure/clojurescript\""))))
 
 (defn run-license [filename subcommand & [args]]
   (let [args (or args "")]


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [ ] This PR corresponds to an #41 

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/neil/blob/main/CHANGELOG.md) file with a description of the addressed issue.

*Aww. Only after figuring this out I just realized there's #162 with a comment. Just following and grabbing that code would've been maybe simpler* 🤦

## Tested with the following:

```
$> ./neil dep search clojure
./neil dep search clojure
;; Tons of results from both Maven and Clojars

$> ./neil dep search "org.clojure/clojurescript"

./neil dep search "org.clojure/clojurescript"
Unable to find org.clojure/clojurescript on Clojars.
:lib org.clojure/clojurescript :version "1.11.121" :description "org.clojure/clojurescript on Maven"


$> ./neil dep search "org.clojure/clojure"

./neil dep search "org.clojure/clojure"
Unable to find org.clojure/clojure on Clojars.
:lib org.clojure/clojure-install :version "0.1.21" :description "org.clojure/clojure-install on Maven"
:lib org.clojure/clojure-contrib :version "1.2.0" :description "org.clojure/clojure-contrib on Maven"
:lib org.clojure/clojure :version "1.12.0-alpha5" :description "org.clojure/clojure on Maven"


$> ./neil dep search "clojurefoo"
./neil dep search "clojurefoo"
Unable to find clojurefoo on Maven.
Unable to find clojurefoo on Clojars.


$> ./neil dep search ""
;; produces help info

$> ./neil dep search 123
;; produces help info

$> ./neil dep search '123'
;; produces help info
```

## Also neil.el was adjusted for the changes