### PR TITLE
pick up the package name when in deps file

### DIFF
--- a/neil.el
+++ b/neil.el
@@ -74,7 +74,8 @@ the dependency to the project (deps.edn only)."
           "Search for Clojure libs: "
           (when (member (file-name-nondirectory (buffer-file-name))
                         '("deps.edn" "project.clj"))
-            (symbol-name (symbol-at-point))))))
+            (when-let ((sym (symbol-at-point)))
+              (symbol-name sym))))))
   (let* ((format-dep-str
           (lambda (lib-name version)
             (let ((build-tool (car (neil--identify-project-build-tool))))

--- a/neil.el
+++ b/neil.el
@@ -70,7 +70,11 @@ name lets you choose its version.
 With `neil-inject-dep-to-project-p' set to t, automatically adds
 the dependency to the project (deps.edn only)."
   (interactive
-   (list (read-from-minibuffer "Search for Clojure libs: ")))
+   (list (read-from-minibuffer
+          "Search for Clojure libs: "
+          (when (member (file-name-nondirectory (buffer-file-name))
+                        '("deps.edn" "project.clj"))
+            (symbol-name (symbol-at-point))))))
   (let* ((format-dep-str
           (lambda (lib-name version)
             (let ((build-tool (car (neil--identify-project-build-tool))))


### PR DESCRIPTION
when called the command, it picks up the package name automatically if the buffer's filename is deps.edn or project.clj

*There's no associated issue; the change is insignificant and doesn't break existing APIs, we can do without changelog update*