### PR TITLE
fix: search with Emacs package

### DIFF
--- a/neil.el
+++ b/neil.el
@@ -90,7 +90,7 @@ the dependency to the project (deps.edn only)."
           (lambda (exe args)
             (let* ((res (shell-command-to-string
                          (format "%s %s" exe args)))
-                   (res (if (or (string-match-p "Error\\|Usage: neil dep search" res)
+                   (res (if (or (string-match-p "Usage: neil dep search" res)
                                 (and (string-match-p "Unable to find.*Maven" res)
                                      (string-match-p "Unable to find.*Clojars" res)))
                             (user-error res)


### PR DESCRIPTION
If one of the packages in search results has a description like "... improving error messages ..", the search bails out

- It's too small of a change for a changelog entry
