### PR TITLE
Fetch latest stable slipset/deps-deploy, instead of hard-coding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 See the [New Clojure project quickstart](https://blog.michielborkent.nl/new-clojure-project-quickstart.html) blog post for a gentle introduction into `neil`.
 
+## 0.2.64
+- [#205](https://github.com/babashka/neil/issues/205): `neil add build` now adds the latest version of `deps-deploy` from Clojars
+
 ## 0.2.63
 
 - [#194](https://github.com/babashka/neil/issues/41): `dep search` in addition to Clojars, now also searches on Maven

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -226,11 +226,12 @@ chmod +x bin/kaocha
   (let [latest-tag (git/latest-github-tag 'clojure/tools.build)
         tag (:name latest-tag)
         sha (-> latest-tag :commit :sha (subs 0 7))
+        slipset-version (latest-stable-clojars-version 'slipset/deps-deploy)
         s (format "
 {:deps {io.github.clojure/tools.build {:git/tag \"%s\" :git/sha \"%s\"}
-        slipset/deps-deploy {:mvn/version \"0.2.0\"}}
+        slipset/deps-deploy {:mvn/version \"%s\"}}
  :ns-default build}"
-                  tag sha)]
+                  tag sha slipset-version)]
     {:s s
      :tag tag
      :sha sha}))

--- a/test/babashka/neil/dep_add_test.clj
+++ b/test/babashka/neil/dep_add_test.clj
@@ -6,4 +6,4 @@
 (deftest latest-version-test
   (is (= "1.0.5" (neil/latest-stable-clojars-version 'hiccup/hiccup)))
   (is (= "2.0.0-RC3" (neil/latest-clojars-version 'hiccup/hiccup)))
-  (is (= "1.11.1" (neil/latest-stable-mvn-version 'org.clojure/clojure))))
+  (is (= "1.11.2" (neil/latest-stable-mvn-version 'org.clojure/clojure))))

--- a/test/babashka/neil/dep_upgrade_test.clj
+++ b/test/babashka/neil/dep_upgrade_test.clj
@@ -66,17 +66,17 @@
 
   (testing "deps can be added with --tag"
     (spit test-file-path "{}")
-    (test-util/neil "dep add :lib clj-kondo/clj-kondo :tag \"v2022.03.08\"" :deps-file test-file-path)
+    (test-util/neil "dep add :lib clj-kondo/clj-kondo :tag \"v2024.03.13\"" :deps-file test-file-path)
     (let [original (get-dep-version 'clj-kondo/clj-kondo)]
-      (is (= "v2022.03.08" (:git/tag original)))
+      (is (= "v2024.03.13" (:git/tag original)))
       (is (:git/sha original))
       (is (:git/url original))))
 
   (testing "deps with :git/tag coords upgrade to latest tags"
     (spit test-file-path "{}")
-    (test-util/neil "dep add :lib clj-kondo/clj-kondo :tag \"v2022.03.08\"" :deps-file test-file-path)
+    (test-util/neil "dep add :lib clj-kondo/clj-kondo :tag \"v2024.03.05\"" :deps-file test-file-path)
     (let [original (get-dep-version 'clj-kondo/clj-kondo)]
-      (is (= "v2022.03.08" (:git/tag original)))
+      (is (= "v2024.03.05" (:git/tag original)))
       (test-util/neil "dep upgrade" :deps-file test-file-path)
       (let [upgraded (get-dep-version 'clj-kondo/clj-kondo)]
         (is (= (:git/url original) (:git/url upgraded)))
@@ -85,9 +85,9 @@
         (is (:git/sha upgraded)))))
 
   (testing "deps with :tag coords are also supported"
-    (spit test-file-path "{:deps {clj-kondo/clj-kondo {:tag \"v2022.03.08\" :sha \"247e538\"}}}")
+    (spit test-file-path "{:deps {clj-kondo/clj-kondo {:tag \"v2024.03.05\" :sha \"58ed56e\"}}}")
     (let [original (get-dep-version 'clj-kondo/clj-kondo)]
-      (is (= "v2022.03.08" (:tag original)))
+      (is (= "v2024.03.05" (:tag original)))
       (test-util/neil "dep upgrade" :deps-file test-file-path)
       (let [upgraded (get-dep-version 'clj-kondo/clj-kondo)]
         (is (:git/tag upgraded))


### PR DESCRIPTION
This is a minor change, which removes the hard-coding of the `slipset/deps-deploy` version in the `build-alias` function.

I have tested the change locally using `bbin`, and see that `neil add build` now uses `slipset/deps-deploy {:mvn/version "0.2.2}`

Closes: #205 
---
Please answer the following questions and leave the below in as part of your PR.

- [X] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code). 

- [X] I have updated the [CHANGELOG.md](https://github.com/babashka/neil/blob/main/CHANGELOG.md) file with a description of the addressed issue.
