### PR TITLE
`neil add kaocha`: normalize alias indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 See the [New Clojure project quickstart](https://blog.michielborkent.nl/new-clojure-project-quickstart.html) blog post for a gentle introduction into `neil`.
 
+## Unreleased
+
+- [#215](https://github.com/babashka/neil/issues/215): `neil add kaocha` adds `:kaocha` alias with irregular indent ([@teodorlu](https://github.com/teodorlu))
+
 ## 0.3.65
 
 - [#209](https://github.com/babashka/neil/issues/209): add newlines between dependencies

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -130,7 +130,7 @@
 (defn add-alias-str
   "Updates deps-file-str by adding alias contents to alias-kw
 
-  Returns a map of :action and :deps-file-str. :deps.file-str is the new deps
+  Returns a map of :action and :deps-file-str. :deps-file-str is the new deps
   file as a string. :action is :replace-str if the string has been
   changed, :noop otherwise.
 

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -109,12 +109,11 @@
  }}
 "))
 
-(defn ensure-deps-file [opts]
-  (let [target (:deps-file opts)]
-    (when-not (fs/exists? target)
-      (spit target (if (= "bb.edn" target)
-                     bb-template
-                     deps-template)))))
+(defn ensure-deps-file [{:keys [deps-file]}]
+  (when-not (fs/exists? deps-file)
+    (spit deps-file (if (= "bb.edn" deps-file)
+                      bb-template
+                      deps-template))))
 
 (defn edn-string [opts] (slurp (:deps-file opts)))
 

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -140,10 +140,12 @@
   - alias-kw - alias keyword, like :kaocha or :dev
   - alias-map - string representing alias contents
   "
-  [deps-file-str alias-kw alias-map]
+  [deps-file-str alias-kw alias-map-str]
   (let [edn-nodes (edn-nodes deps-file-str)
         edn (edn/read-string deps-file-str)
-        existing-aliases (get-in edn [:aliases])]
+        existing-aliases (get-in edn [:aliases])
+        alias-map (edn/read-string alias-map-str)]
+    (assert (map? alias-map) "Alias map must be a map")
     (if-not (get existing-aliases alias-kw)
       (let [node-with-aliases-key (if-not (seq existing-aliases)
                                     (r/assoc edn-nodes :aliases {})
@@ -151,7 +153,7 @@
             node-with-new-alias (reduce (fn [node [k v]]
                                           (r/assoc-in node [:aliases alias-kw k] v))
                                         node-with-aliases-key
-                                        (edn/read-string alias-map))]
+                                        (into (sorted-map) alias-map))]
         {:action :replace-str
          :deps-file-str (str (-> node-with-new-alias str rw/clean-trailing-whitespace)
                              "\n")})

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -132,8 +132,15 @@
 
   Returns a map of :action and :deps-file-str. :deps.file-str is the new deps
   file as a string. :action is :replace-str if the string has been
-  changed, :noop otherwise."
-  [deps-file-str alias-kw alias-contents]
+  changed, :noop otherwise.
+
+  Args:
+
+  - deps-file-str - string representing deps.edn or bb.edn
+  - alias-kw - alias keyword, like :kaocha or :dev
+  - alias-map - string representing alias contents
+  "
+  [deps-file-str alias-kw alias-map]
   (let [edn-nodes (edn-nodes deps-file-str)
         edn (edn/read-string deps-file-str)
         existing-aliases (get-in edn [:aliases])
@@ -150,7 +157,7 @@
                     edn-nodes)
                   (r/update :aliases
                             (fn [aliases]
-                              (let [s (rw/indent alias-contents 1)
+                              (let [s (rw/indent alias-map 1)
                                     alias-nodes (r/parse-string s)
                                     aliases' (r/assoc aliases alias-node alias-nodes)]
                                 (if-not (seq existing-aliases)

--- a/test/babashka/neil/add_alias_test.clj
+++ b/test/babashka/neil/add_alias_test.clj
@@ -1,0 +1,19 @@
+(ns babashka.neil.add-alias-test
+  (:require
+   [babashka.neil :as neil]
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is]]))
+
+(def kaocha-alias "\n{:extra-deps {lambdaisland/kaocha {:mvn/version \"1.91.1392\"}}\n :main-opts [\"-m\" \"kaocha.runner\"]}")
+
+(defn trim= [s1 s2]
+  (= (str/trim s1)
+     (str/trim s2)))
+
+(deftest add-alias-str
+  (is (trim= "
+{:aliases
+ {:kaocha ;; added by neil
+  {:extra-deps {lambdaisland/kaocha {:mvn/version \"1.91.1392\"}}
+   :main-opts [\"-m\" \"kaocha.runner\"]}}}"
+             (:deps-file-str (neil/add-alias-str "{}" :kaocha kaocha-alias)))))

--- a/test/babashka/neil/add_alias_test.clj
+++ b/test/babashka/neil/add_alias_test.clj
@@ -10,10 +10,53 @@
   (= (str/trim s1)
      (str/trim s2)))
 
-(deftest add-alias-str
+(deftest add-alias-str-good1
   (is (trim= "
 {:aliases
  {:kaocha ;; added by neil
   {:extra-deps {lambdaisland/kaocha {:mvn/version \"1.91.1392\"}}
    :main-opts [\"-m\" \"kaocha.runner\"]}}}"
              (:deps-file-str (neil/add-alias-str "{}" :kaocha kaocha-alias)))))
+
+(deftest add-alias-str-weird1
+  ;; weird space in between.
+  (is (trim= "
+{:aliases {:dev {}
+
+ :kaocha ;; added by neil
+ {:extra-deps {lambdaisland/kaocha {:mvn/version \"1.91.1392\"}}
+  :main-opts [\"-m\" \"kaocha.runner\"]}}}"
+             (:deps-file-str (neil/add-alias-str "{:aliases {:dev {}}}" :kaocha kaocha-alias)))))
+
+(deftest add-alias-str-weird2
+  ;; weird space in between.
+  (is (trim= "
+{:aliases
+ {:dev {}
+
+ :kaocha ;; added by neil
+ {:extra-deps {lambdaisland/kaocha {:mvn/version \"1.91.1392\"}}
+  :main-opts [\"-m\" \"kaocha.runner\"]}}}"
+             (:deps-file-str (neil/add-alias-str (str/trim "
+{:aliases
+ {:dev {}}}"
+                                                           )
+                                                 :kaocha kaocha-alias)))))
+
+(comment
+  (defn escape-quote [s]
+    (str/escape s {\" "\\\""}))
+
+  (-> "hello \"you\"!" escape-quote escape-quote escape-quote)
+  (def println2 (comp println escape-quote))
+
+  (println)
+
+  (-> (:deps-file-str (neil/add-alias-str (str/trim "
+{:aliases
+ {:dev {}}}"
+                                                    )
+                                          :kaocha kaocha-alias))
+      println2)
+
+  )

--- a/test/babashka/neil/add_alias_test.clj
+++ b/test/babashka/neil/add_alias_test.clj
@@ -1,6 +1,7 @@
 (ns babashka.neil.add-alias-test
   (:require
    [babashka.neil :as neil]
+   [borkdude.rewrite-edn :as r]
    [clojure.string :as str]
    [clojure.test :refer [deftest is]]))
 
@@ -59,4 +60,26 @@
                                           :kaocha kaocha-alias))
       println2)
 
+  )
+
+(comment
+  ;; how do I use rewrite-edn?
+
+  (str (r/assoc (r/parse-string "{:x 1\n :y 2}") :key "value"))
+
+  (let [s (str/triml "
+{:deps {}
+ :aliases {}}
+")]
+    (-> (r/parse-string s)
+        (r/assoc-in [:aliases :kaocha] {})
+        (r/assoc-in [:aliases :dev] {})
+        str
+        println))
+  ;; =>
+  ;; {:deps {}
+  ;;  :aliases {:kaocha {}
+  ;;            :dev {}}}
+
+  ;; this works just perfectly.
   )

--- a/test/babashka/neil/add_alias_test.clj
+++ b/test/babashka/neil/add_alias_test.clj
@@ -82,4 +82,14 @@
   ;;            :dev {}}}
 
   ;; this works just perfectly.
+
+  (let [s (str/triml "
+{:deps {}
+ :aliases {:dev {}}}
+")]
+    (-> (r/parse-string s)
+        (r/assoc-in [:aliases :kaocha :extra-deps] {:lambdaisland/kaocha {:mvn/version "1.91.1392"}},)
+        (r/assoc-in [:aliases :kaocha :main-opts] ["-m" "kaocha.runner"])
+        str
+        println2))
   )

--- a/test/babashka/neil/add_alias_test.clj
+++ b/test/babashka/neil/add_alias_test.clj
@@ -11,85 +11,69 @@
   (= (str/trim s1)
      (str/trim s2)))
 
-(deftest add-alias-str-good1
-  (is (trim= "
-{:aliases
- {:kaocha ;; added by neil
-  {:extra-deps {lambdaisland/kaocha {:mvn/version \"1.91.1392\"}}
-   :main-opts [\"-m\" \"kaocha.runner\"]}}}"
-             (:deps-file-str (neil/add-alias-str "{}" :kaocha kaocha-alias)))))
+(deftest add-alias-str-empty-deps-edn
+    (is (trim= "
+{:aliases {:kaocha {:extra-deps {lambdaisland/kaocha {:mvn/version \"1.91.1392\"}}
+                    :main-opts [\"-m\" \"kaocha.runner\"]}}}
+"
+               (:deps-file-str (neil/add-alias-str "{}" :kaocha kaocha-alias)))))
 
-(deftest add-alias-str-weird1
-  ;; weird space in between.
-  (is (trim= "
-{:aliases {:dev {}
-
- :kaocha ;; added by neil
- {:extra-deps {lambdaisland/kaocha {:mvn/version \"1.91.1392\"}}
-  :main-opts [\"-m\" \"kaocha.runner\"]}}}"
-             (:deps-file-str (neil/add-alias-str "{:aliases {:dev {}}}" :kaocha kaocha-alias)))))
-
-(deftest add-alias-str-weird2
-  ;; weird space in between.
-  (is (trim= "
+(deftest add-alias-str-deps-edn-with-dev-alias
+    (is (trim= "
 {:aliases
  {:dev {}
+  :kaocha {:extra-deps {lambdaisland/kaocha {:mvn/version \"1.91.1392\"}}
+           :main-opts [\"-m\" \"kaocha.runner\"]}}}
+"
+               (:deps-file-str (neil/add-alias-str "{:aliases
+ {:dev {}}}" :kaocha kaocha-alias)))))
 
- :kaocha ;; added by neil
- {:extra-deps {lambdaisland/kaocha {:mvn/version \"1.91.1392\"}}
-  :main-opts [\"-m\" \"kaocha.runner\"]}}}"
-             (:deps-file-str (neil/add-alias-str (str/trim "
-{:aliases
- {:dev {}}}"
-                                                           )
-                                                 :kaocha kaocha-alias)))))
+(deftest add-alias-str-simplified-neil-deps-edn
+  (let [input-deps-edn (str/trim "
+{:deps {org.babashka/http-client {:mvn/version \"0.1.4\"}
+        org.babashka/cli {:mvn/version \"0.8.58\"}
+        cheshire/cheshire {:mvn/version \"5.11.0\"}
+        version-clj/version-clj {:mvn/version \"2.0.2\"}}
+ :aliases
+ {:dev
+  {:extra-paths [\"test\"]
+   :extra-deps {io.github.cognitect-labs/test-runner
+                {:git/url \"https://github.com/cognitect-labs/test-runner\"
+                 :git/tag \"v0.5.1\"
+                 :git/sha \"dfb30dd\"}}}}}
+")
+        expected-deps-edn (str/trim "
+{:deps {org.babashka/http-client {:mvn/version \"0.1.4\"}
+        org.babashka/cli {:mvn/version \"0.8.58\"}
+        cheshire/cheshire {:mvn/version \"5.11.0\"}
+        version-clj/version-clj {:mvn/version \"2.0.2\"}}
+ :aliases
+ {:dev
+  {:extra-paths [\"test\"]
+   :extra-deps {io.github.cognitect-labs/test-runner
+                {:git/url \"https://github.com/cognitect-labs/test-runner\"
+                 :git/tag \"v0.5.1\"
+                 :git/sha \"dfb30dd\"}}}
+  :kaocha {:extra-deps {lambdaisland/kaocha {:mvn/version \"1.91.1392\"}}
+           :main-opts [\"-m\" \"kaocha.runner\"]}}}
+")]
+    (is (trim= expected-deps-edn
+               (:deps-file-str (neil/add-alias-str input-deps-edn :kaocha kaocha-alias))))))
 
 (comment
+  ;; Some helper code to generate the strings for the tests
+
   (defn escape-quote [s]
     (str/escape s {\" "\\\""}))
 
-  (-> "hello \"you\"!" escape-quote escape-quote escape-quote)
   (def println2 (comp println escape-quote))
 
-  (println)
-
-  (-> (:deps-file-str (neil/add-alias-str (str/trim "
+  (let [s (str/trim "
 {:aliases
- {:dev {}}}"
-                                                    )
-                                          :kaocha kaocha-alias))
-      println2)
-
-  )
-
-(comment
-  ;; how do I use rewrite-edn?
-
-  (str (r/assoc (r/parse-string "{:x 1\n :y 2}") :key "value"))
-
-  (let [s (str/triml "
-{:deps {}
- :aliases {}}
-")]
-    (-> (r/parse-string s)
-        (r/assoc-in [:aliases :kaocha] {})
-        (r/assoc-in [:aliases :dev] {})
-        str
-        println))
-  ;; =>
-  ;; {:deps {}
-  ;;  :aliases {:kaocha {}
-  ;;            :dev {}}}
-
-  ;; this works just perfectly.
-
-  (let [s (str/triml "
-{:deps {}
- :aliases {:dev {}}}
-")]
-    (-> (r/parse-string s)
-        (r/assoc-in [:aliases :kaocha :extra-deps] {:lambdaisland/kaocha {:mvn/version "1.91.1392"}},)
-        (r/assoc-in [:aliases :kaocha :main-opts] ["-m" "kaocha.runner"])
-        str
+ {:dev {}}}
+")
+        ]
+    (-> (:deps-file-str (neil/add-alias-str s :kaocha kaocha-alias))
         println2))
-  )
+
+  :rcf)

--- a/test/babashka/neil/add_alias_test.clj
+++ b/test/babashka/neil/add_alias_test.clj
@@ -1,7 +1,6 @@
 (ns babashka.neil.add-alias-test
   (:require
    [babashka.neil :as neil]
-   [borkdude.rewrite-edn :as r]
    [clojure.string :as str]
    [clojure.test :refer [deftest is]]))
 


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
    - https://github.com/babashka/neil/issues/215

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/neil/blob/main/CHANGELOG.md) file with a description of the addressed issue.

## Problem

This PR addresses #215. Currently, `neil add kaocha` may add the `:kaocha` alias with one fewer indent than expected, leaving a `deps.edn` file like this:

```clojure
{:paths ["src"]
 :deps {babashka/fs {:mvn/version "0.2.16"}
        babashka/process {:mvn/version "0.4.16"}
        borkdude/edamame {:mvn/version "1.4.25"}
        cheshire/cheshire {:mvn/version "5.11.0"}
        enlive/enlive {:mvn/version "1.1.6"}
        org.babashka/cli {:mvn/version "0.6.44"}
        org.clj-commons/hickory {:mvn/version "0.7.3"}
        org.clojure/data.xml {:mvn/version "0.0.8"}}
 :aliases
 {:dev
  {:extra-paths ["dev" "test"]
   :extra-deps {io.github.nextjournal/clerk {:mvn/version "0.13.842"}}}

 :kaocha ;; added by neil
 {:extra-deps {lambdaisland/kaocha {:mvn/version "1.91.1392"}}
  :main-opts ["-m" "kaocha.runner"]}}}
```

The `:dev` and `:kaocha` aliases don't line up.

## Proposed solution

- Split `add-alias` into a pure part (`add-alias-str`) and an impure part (`add-alias`)
- Implement `add-alias-str` using only `borkdude.rewrite-edn/assoc-in`, avoid manually calculating indent spaces

## Tests

I've tried to write the tests so that it's easy to see visually how indents line up.

## Future work

If we merge this PR, we may consider storing `kaocha-alias` and `nrepl-alias` as clojure data. Currently, they are strings:

https://github.com/teodorlu/neil/blob/02c0fc9c68db2e9f0cd876605eb1aca6ab7a013f/src/babashka/neil.clj#L205-L209

https://github.com/teodorlu/neil/blob/02c0fc9c68db2e9f0cd876605eb1aca6ab7a013f/src/babashka/neil.clj#L225-L229