### PR TITLE
Store provided aliases as data instead of strings

### DIFF
--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -140,11 +140,11 @@
   - alias-kw - alias keyword, like :kaocha or :dev
   - alias-map - string representing alias contents
   "
-  [deps-file-str alias-kw alias-map-str]
+  [deps-file-str alias-kw alias-map-or-map-str]
   (let [edn-nodes (edn-nodes deps-file-str)
         edn (edn/read-string deps-file-str)
         existing-aliases (get-in edn [:aliases])
-        alias-map (edn/read-string alias-map-str)]
+        alias-map (cond-> alias-map-or-map-str string? edn/read-string)]
     (assert (map? alias-map) "Alias map must be a map")
     (if-not (get existing-aliases alias-kw)
       (let [node-with-aliases-key (if-not (seq existing-aliases)

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -231,7 +231,7 @@ chmod +x bin/kaocha
     (print-help cmd)
     (add-alias opts :nrepl (nrepl-alias))))
 
-(defn build-alias [_opts]
+(defn build-alias []
   (let [latest-tag (git/latest-github-tag 'clojure/tools.build)
         tag (:name latest-tag)
         sha (-> latest-tag :commit :sha (subs 0 7))
@@ -321,7 +321,7 @@ chmod +x bin/kaocha
         (spit "build.clj" (build-file opts))
         (println "[neil] Project build.clj already exists."))
       (ensure-deps-file opts)
-      (let [ba (build-alias opts)]
+      (let [ba (build-alias)]
         (when (= ::update (add-alias opts :build (:alias ba)))
           (println "[neil] Updating tools build to newest git tag + sha.")
           (let [edn-string (edn-string opts)

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -202,7 +202,7 @@
     (is (= :foo :bar))))
 " test-ns (name pn)))))))))
 
-(defn kaocha-alias []
+(defn kaocha-alias-latest []
   (let [version (latest-stable-clojars-version 'lambdaisland/kaocha)]
     {:extra-deps {'lambdaisland/kaocha {:mvn/version version}},
      :main-opts ["-m" "kaocha.runner"]}))
@@ -211,7 +211,7 @@
   (if (:help opts)
     (print-help cmd)
     (do
-      (add-alias opts :kaocha (kaocha-alias))
+      (add-alias opts :kaocha (kaocha-alias-latest))
       (println (str/trim "
 If you wish to create a `bin/kaocha` file, copy and run the following:
 
@@ -221,7 +221,7 @@ clojure -M:kaocha \"$@\"' > bin/kaocha && \\
 chmod +x bin/kaocha
 ")))))
 
-(defn nrepl-alias []
+(defn nrepl-alias-latest []
   (let [version (latest-stable-clojars-version 'nrepl/nrepl)]
     {:extra-deps {'nrepl/nrepl {:mvn/version version}},
      :main-opts ["-m" "nrepl.cmdline" "--interactive" "--color"]}))
@@ -229,9 +229,9 @@ chmod +x bin/kaocha
 (defn add-nrepl [{:keys [opts] :as cmd}]
   (if (:help opts)
     (print-help cmd)
-    (add-alias opts :nrepl (nrepl-alias))))
+    (add-alias opts :nrepl (nrepl-alias-latest))))
 
-(defn build-alias []
+(defn build-alias-latest []
   (let [latest-tag (git/latest-github-tag 'clojure/tools.build)
         tag (:name latest-tag)
         sha (-> latest-tag :commit :sha (subs 0 7))
@@ -320,7 +320,7 @@ chmod +x bin/kaocha
         (spit "build.clj" (build-file opts))
         (println "[neil] Project build.clj already exists."))
       (ensure-deps-file opts)
-      (let [ba (build-alias)]
+      (let [ba (build-alias-latest)]
         (when (= ::update (add-alias opts :build (:alias ba)))
           (println "[neil] Updating tools build to newest git tag + sha.")
           (let [edn-string (edn-string opts)

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -235,12 +235,7 @@ chmod +x bin/kaocha
   (let [latest-tag (git/latest-github-tag 'clojure/tools.build)
         tag (:name latest-tag)
         sha (-> latest-tag :commit :sha (subs 0 7))
-        slipset-version (latest-stable-clojars-version 'slipset/deps-deploy)
-        s (format "
-{:deps {io.github.clojure/tools.build {:git/tag \"%s\" :git/sha \"%s\"}
-        slipset/deps-deploy {:mvn/version \"%s\"}}
- :ns-default build}"
-                  tag sha slipset-version)]
+        slipset-version (latest-stable-clojars-version 'slipset/deps-deploy)]
     {:tag tag
      :sha sha
      :alias {:deps

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -241,8 +241,7 @@ chmod +x bin/kaocha
         slipset/deps-deploy {:mvn/version \"%s\"}}
  :ns-default build}"
                   tag sha slipset-version)]
-    {:s s
-     :tag tag
+    {:tag tag
      :sha sha
      :alias {:deps
              {'io.github.clojure/tools.build {:git/tag tag, :git/sha sha},

--- a/test/babashka/neil/add_alias_test.clj
+++ b/test/babashka/neil/add_alias_test.clj
@@ -12,14 +12,14 @@
   (= (str/trim s1)
      (str/trim s2)))
 
-(deftest add-alias-str-empty-deps-edn
+(deftest add-alias-kaocha-small
     (is (trim= "
 {:aliases {:kaocha {:extra-deps {lambdaisland/kaocha {:mvn/version \"1.91.1392\"}}
                     :main-opts [\"-m\" \"kaocha.runner\"]}}}
 "
                (:deps-file-str (neil/add-alias-str "{}" :kaocha kaocha-alias)))))
 
-(deftest add-alias-str-deps-edn-with-dev-alias
+(deftest add-alias-kaocha-bigger-1
     (is (trim= "
 {:aliases
  {:dev {}
@@ -29,7 +29,7 @@
                (:deps-file-str (neil/add-alias-str "{:aliases
  {:dev {}}}" :kaocha kaocha-alias)))))
 
-(deftest add-alias-str-simplified-neil-deps-edn
+(deftest add-alias-kaocha-bigger-2
   (let [input-deps-edn (str/trim "
 {:deps {org.babashka/http-client {:mvn/version \"0.1.4\"}
         org.babashka/cli {:mvn/version \"0.8.58\"}

--- a/test/babashka/neil/add_alias_test.clj
+++ b/test/babashka/neil/add_alias_test.clj
@@ -4,7 +4,9 @@
    [clojure.string :as str]
    [clojure.test :refer [deftest is]]))
 
-(def kaocha-alias "\n{:extra-deps {lambdaisland/kaocha {:mvn/version \"1.91.1392\"}}\n :main-opts [\"-m\" \"kaocha.runner\"]}")
+(def kaocha-alias
+  '{:extra-deps {lambdaisland/kaocha {:mvn/version "1.91.1392"}},
+    :main-opts ["-m" "kaocha.runner"]})
 
 (defn trim= [s1 s2]
   (= (str/trim s1)


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
    - This PR completes planned follow-up work from https://github.com/babashka/neil/issues/215

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/neil/blob/main/CHANGELOG.md) file with a description of the addressed issue.
    - Changelog entry already includes an entry for https://github.com/babashka/neil/issues/215

- [x] I have considered whether I should add more tests covering the code I've changed.
    - Tests have been updated to reflect new behavior

## Problem: storing strings and converting to Clojure data is unncessary

## Proposed solution: just store EDN

Effects:

- We can return Clojure data for aliases such as `neil/kaocha-alias`
- We don't need to convert from strings to Clojure data in our implementation

## PR completion status

I think what I've got now is good. But I'd like to look into `add-build`, I think some code can be deleted.