### PR TITLE
`dep add`: avoid long lines in `:aliases`

### DIFF
--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -132,7 +132,7 @@
 
     {:p {:x 1 :y 2}}
 
-  into a seq of assoc-in pairs such as ´
+  into a seq of assoc-in pairs such as
 
     '([[:p :x] 1]
       [[:p :y] 2])

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -148,14 +148,7 @@
                         (value->assoc-in-pairs (into root-path [k]) v))
                       value))))
 
-(comment
-
-  (def some-alias (kaocha-alias-latest))
-  (def some-pairs (value->assoc-in-pairs [:aliases :kaocha] some-alias))
-
-  (sort some-pairs)
-
-  :rcf)
+#_ (value->assoc-in-pairs [:aliases :kaocha] (kaocha-alias-latest))
 
 (defn add-alias-str
   "Updates deps-file-str by adding alias contents to alias-kw

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -134,9 +134,8 @@
 
   into a seq of assoc-in pairs such as
 
-    '([[:p :x] 1]
-      [[:p :y] 2])
-  "
+     [[[:p :x] 1]
+      [[:p :y] 2]]"
   [root-path value]
   (assert (vector? root-path) "root-path must be vector")
   (cond (not (map? value))

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -138,7 +138,7 @@
       [[:p :y] 2])
   "
   [root-path value]
-  (assert (vector? root-path) "Root path must be vector")
+  (assert (vector? root-path) "root-path must be vector")
   (cond (not (map? value))
         (list [root-path value])
 

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -139,7 +139,7 @@
   [root-path value]
   (assert (vector? root-path) "root-path must be vector")
   (cond (not (map? value))
-        (list [root-path value])
+        [[root-path value]]
 
         :else
         (into []

--- a/test/babashka/neil/add_alias_test.clj
+++ b/test/babashka/neil/add_alias_test.clj
@@ -7,8 +7,8 @@
 (deftest value->assoc-in-pairs-test
   (is (= (neil/value->assoc-in-pairs [:x] 1)
          '([[:x] 1])))
-  (is (= (list [[:p :x] 1]
-               [[:p :y] 2])
+  (is (= '([[:p :x] 1]
+           [[:p :y] 2])
          (neil/value->assoc-in-pairs [] {:p {:x 1 :y 2}}))))
 
 (def kaocha-alias

--- a/test/babashka/neil/add_alias_test.clj
+++ b/test/babashka/neil/add_alias_test.clj
@@ -4,6 +4,13 @@
    [clojure.string :as str]
    [clojure.test :refer [deftest is]]))
 
+(deftest value->assoc-in-pairs-test
+  (is (= (neil/value->assoc-in-pairs [:x] 1)
+         '([[:x] 1])))
+  (is (= (list [[:p :x] 1]
+               [[:p :y] 2])
+         (neil/value->assoc-in-pairs [] {:p {:x 1 :y 2}}))))
+
 (def kaocha-alias
   '{:extra-deps {lambdaisland/kaocha {:mvn/version "1.91.1392"}},
     :main-opts ["-m" "kaocha.runner"]})

--- a/test/babashka/neil/add_alias_test.clj
+++ b/test/babashka/neil/add_alias_test.clj
@@ -15,6 +15,15 @@
   '{:extra-deps {lambdaisland/kaocha {:mvn/version "1.91.1392"}},
     :main-opts ["-m" "kaocha.runner"]})
 
+(def nrepl-alias
+  '{:extra-deps
+    {nrepl/nrepl {:mvn/version "1.1.2"},
+     cider/cider-nrepl {:mvn/version "0.49.0"},
+     refactor-nrepl/refactor-nrepl {:mvn/version "3.10.0"}},
+    :main-opts
+    ["-m" "nrepl.cmdline" "--interactive" "--color"
+     "--middleware" "[cider.nrepl/cider-middleware,refactor-nrepl.middleware/wrap-refactor]"]})
+
 (defn trim= [s1 s2]
   (= (str/trim s1)
      (str/trim s2)))

--- a/test/babashka/neil/add_alias_test.clj
+++ b/test/babashka/neil/add_alias_test.clj
@@ -77,20 +77,37 @@
     (is (trim= expected-deps-edn
                (:deps-file-str (neil/add-alias-str input-deps-edn :kaocha kaocha-alias))))))
 
+(deftest add-alias-nrepl
+  (let [input-deps-edn (str/trim "
+{:aliases
+ {:dev {}}}
+")
+        expected-deps-edn (str/trim "
+{:aliases
+ {:dev {}
+  :nrepl {:extra-deps {nrepl/nrepl {:mvn/version \"1.1.2\"}
+                       cider/cider-nrepl {:mvn/version \"0.49.0\"}
+                       refactor-nrepl/refactor-nrepl {:mvn/version \"3.10.0\"}}
+          :main-opts [\"-m\" \"nrepl.cmdline\" \"--interactive\" \"--color\" \"--middleware\" \"[cider.nrepl/cider-middleware,refactor-nrepl.middleware/wrap-refactor]\"]}}}
+")]
+    (is (trim= expected-deps-edn
+               (:deps-file-str (neil/add-alias-str input-deps-edn :nrepl nrepl-alias)))))
+  )
+
 (comment
-  ;; Some helper code to generate the strings for the tests
+  ;; Some helper code to generate the strings for the tests above
 
-  (defn escape-quote [s]
-    (str/escape s {\" "\\\""}))
-
-  (def println2 (comp println escape-quote))
+  (do
+    (defn escape-quote [s]
+      (str/escape s {\" "\\\""}))
+    (def println2 (comp println escape-quote)))
 
   (let [s (str/trim "
 {:aliases
  {:dev {}}}
 ")
         ]
-    (-> (:deps-file-str (neil/add-alias-str s :kaocha kaocha-alias))
+    (-> (:deps-file-str (neil/add-alias-str s :nrepl nrepl-alias))
         println2))
 
   :rcf)


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
    - https://github.com/babashka/neil/issues/224

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/neil/blob/main/CHANGELOG.md) file with a description of the addressed issue.
    - I consider this work to be covered by the changelog entry for https://github.com/babashka/neil/issues/215

- [x] I have considered whether I should add more tests covering the code I've changed.
    - New tests have been added for the new function `babashka.neil/value->assoc-in-pairs`, and a test for `babashka.neil/add-alias-str`, covering the case where the `:nrepl` alias produced very long lines in `:extra-deps`

## Behavior before this PR

Given this `deps.edn`

```clojure
{:aliases
 {:dev {}}}
```

, `neil dep add nrepl` would produce this `deps.edn`:

```clojure
{:aliases
 {:dev {}
  :nrepl {:extra-deps {nrepl/nrepl {:mvn/version "1.1.2"} cider/cider-nrepl {:mvn/version "0.49.0"} refactor-nrepl/refactor-nrepl {:mvn/version "3.10.0"}}
          :main-opts ["-m" "nrepl.cmdline" "--interactive" "--color" "--middleware" "[cider.nrepl/cider-middleware,refactor-nrepl.middleware/wrap-refactor]"]}}}
```

## Behavior after this PR

With the same `deps.edn`, `neil dep add nrepl` would produce this `deps.edn`:

```clojure
{:aliases
 {:dev {}
  :nrepl {:extra-deps {nrepl/nrepl {:mvn/version "1.1.2"}
                       cider/cider-nrepl {:mvn/version "0.49.0"}
                       refactor-nrepl/refactor-nrepl {:mvn/version "3.10.0"}}
          :main-opts ["-m" "nrepl.cmdline" "--interactive" "--color" "--middleware" "[cider.nrepl/cider-middleware,refactor-nrepl.middleware/wrap-refactor]"]}}}
```