### PR TITLE
add-alias-str: fix docstring

### DIFF
--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -160,7 +160,7 @@
 
   - deps-file-str - string representing deps.edn or bb.edn
   - alias-kw - alias keyword, like :kaocha or :dev
-  - alias-map - string representing alias contents
+  - alias-map - alias map, like {:extra-paths [\"test\"]}
   "
   [deps-file-str alias-kw alias-map]
   (let [edn-nodes (edn-nodes deps-file-str)


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
    - https://github.com/babashka/neil/issues/215

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/neil/blob/main/CHANGELOG.md) file with a description of the addressed issue.
    - Changelog entry already exists for https://github.com/babashka/neil/issues/215

- [x] I have considered whether I should add more tests covering the code I've changed.
    - The code changes a docstring, I don't think new tests are required.

-----

In #221, I changed `add-alias-str`s signature to work on Clojure maps instead of strings. In that PR, I forgot to change the docstring. This PR changes the docstring.