### PR TITLE
Dependency versions can be pinned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ See the [New Clojure project quickstart](https://blog.michielborkent.nl/new-cloj
 
 - [#215](https://github.com/babashka/neil/issues/215): `neil add kaocha` adds `:kaocha` alias with irregular indent ([@teodorlu](https://github.com/teodorlu))
 - [#220](https://github.com/babashka/neil/issues/220): `neil add` print helptext rather than crash ([@teodorlu](https://github.com/teodorlu))
+- [#227](https://github.com/babashka/neil/issues/227): Support `:neil/pinned true` to skip version updates when updating with `neil dep add`
 
 ## 0.3.65
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ See the [New Clojure project quickstart](https://blog.michielborkent.nl/new-cloj
 
 - [#215](https://github.com/babashka/neil/issues/215): `neil add kaocha` adds `:kaocha` alias with irregular indent ([@teodorlu](https://github.com/teodorlu))
 - [#220](https://github.com/babashka/neil/issues/220): `neil add` print helptext rather than crash ([@teodorlu](https://github.com/teodorlu))
-- [#227](https://github.com/babashka/neil/issues/227): Support `:neil/pinned true` to skip version updates when updating with `neil dep add`
+- [#227](https://github.com/babashka/neil/issues/227): Support `:neil/pinned true` to skip version updates when updating with `neil dep upgrade`
 
 ## 0.3.65
 

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -16,30 +16,30 @@
    [clojure.string :as str]
    [clojure.set :as set]))
 
-(def spec {:alias {:ref "<alias>"
-                   :desc "Add to alias <alias>."
-                   :coerce :keyword}
+(def spec {:lib {:desc "Fully qualified library name."}
+           :version {:desc "Optional. When not provided, picks newest version from Clojars or Maven Central."
+                     :coerce :string}
+           :sha {:desc "When provided, assumes lib refers to Github repo."
+                 :coerce :string}
+           :latest-sha {:coerce :boolean :desc "When provided, assumes lib refers to Github repo and then picks latest SHA from it."}
+           :tag {:desc "When provided, assumes lib refers to Github repo."
+                 :coerce :string}
+           :latest-tag {:coerce :boolean :desc "When provided, assumes lib refers to Github repo and then picks latest tag from it."}
+           :deps/root {:desc "Sets deps/root to give value."}
            :as {:desc "Use as dependency name in deps.edn"
                 :coerce :symbol}
+           :alias {:ref "<alias>"
+                   :desc "Add to alias <alias>."
+                   :coerce :keyword}
            :deps-file {:ref "<file>"
                        :desc "Add to <file> instead of deps.edn."
                        :coerce :string
                        :default "deps.edn"}
-           :deps/root {:desc "Sets deps/root to give value."}
+           :limit {:coerce :long}
            :dry-run {:coerce :boolean
                      :desc "dep upgrade only. Prevents updates to deps.edn."}
-           :latest-sha {:coerce :boolean :desc "When provided, assumes lib refers to Github repo and then picks latest SHA from it."}
-           :latest-tag {:coerce :boolean :desc "When provided, assumes lib refers to Github repo and then picks latest tag from it."}
-           :lib {:desc "Fully qualified library name."}
-           :limit {:coerce :long :desc "When provided, overrides number of versions from Maven/Clojars"}
            :no-aliases {:coerce :boolean
-                        :desc "Prevents updates to alias :extra-deps when upgrading."}
-           :sha {:desc "When provided, assumes lib refers to Github repo."
-                 :coerce :string}
-           :tag {:desc "When provided, assumes lib refers to Github repo."
-                 :coerce :string}
-           :version {:desc "Optional. When not provided, picks newest version from Clojars or Maven Central."
-                     :coerce :string}})
+                        :desc "Prevents updates to alias :extra-deps when upgrading."}})
 
 (def windows? (fs/windows?))
 

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -474,8 +474,8 @@ chmod +x bin/kaocha
                     (-> nodes
                         (r/assoc-in (conj path :deps/root) root))
                     nodes)
-            nodes (if (:pin opts)
-                    (r/assoc-in nodes (conj path :neil/pinned) true)
+            nodes (if (not= ::undefined (:pin opts ::undefined))
+                    (r/assoc-in nodes (conj path :neil/pinned) (:pin opts))
                     nodes)
             s (str (str/trim (str nodes)) "\n")]
         (when-not missing?

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -750,6 +750,7 @@ Examples:
   neil dep upgrade :lib clj-kondo/clj-kondo  ; update a single dep.
 "))
     (System/exit 0))
+
   (let [lib           (some-> opts :lib symbol)
         alias         (some-> opts :alias)
         deps-to-check (->> (opts->specified-deps opts)

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -935,8 +935,7 @@ test
      :fn (fn [{:keys [opts] :as m}]
            (if (:version opts)
              (neil-version/print-version)
-             (print-help m)))}
-    {:cmds ["debug"] :fn prn}]
+             (print-help m)))}]
    *command-line-args*
    {:spec spec
     :exec-args {:deps-file "deps.edn"}})

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -31,7 +31,7 @@
            :latest-sha {:coerce :boolean :desc "When provided, assumes lib refers to Github repo and then picks latest SHA from it."}
            :latest-tag {:coerce :boolean :desc "When provided, assumes lib refers to Github repo and then picks latest tag from it."}
            :lib {:desc "Fully qualified library name."}
-           :limit {:coerce :long}
+           :limit {:coerce :long :desc "When provided, overrides number of versions from Maven/Clojars"}
            :no-aliases {:coerce :boolean
                         :desc "Prevents updates to alias :extra-deps when upgrading."}
            :sha {:desc "When provided, assumes lib refers to Github repo."

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -16,30 +16,30 @@
    [clojure.string :as str]
    [clojure.set :as set]))
 
-(def spec {:lib {:desc "Fully qualified library name."}
-           :version {:desc "Optional. When not provided, picks newest version from Clojars or Maven Central."
-                     :coerce :string}
-           :sha {:desc "When provided, assumes lib refers to Github repo."
-                 :coerce :string}
-           :latest-sha {:coerce :boolean :desc "When provided, assumes lib refers to Github repo and then picks latest SHA from it."}
-           :tag {:desc "When provided, assumes lib refers to Github repo."
-                 :coerce :string}
-           :latest-tag {:coerce :boolean :desc "When provided, assumes lib refers to Github repo and then picks latest tag from it."}
-           :deps/root {:desc "Sets deps/root to give value."}
-           :as {:desc "Use as dependency name in deps.edn"
-                :coerce :symbol}
-           :alias {:ref "<alias>"
+(def spec {:alias {:ref "<alias>"
                    :desc "Add to alias <alias>."
                    :coerce :keyword}
+           :as {:desc "Use as dependency name in deps.edn"
+                :coerce :symbol}
            :deps-file {:ref "<file>"
                        :desc "Add to <file> instead of deps.edn."
                        :coerce :string
                        :default "deps.edn"}
-           :limit {:coerce :long}
+           :deps/root {:desc "Sets deps/root to give value."}
            :dry-run {:coerce :boolean
                      :desc "dep upgrade only. Prevents updates to deps.edn."}
+           :latest-sha {:coerce :boolean :desc "When provided, assumes lib refers to Github repo and then picks latest SHA from it."}
+           :latest-tag {:coerce :boolean :desc "When provided, assumes lib refers to Github repo and then picks latest tag from it."}
+           :lib {:desc "Fully qualified library name."}
+           :limit {:coerce :long}
            :no-aliases {:coerce :boolean
-                        :desc "Prevents updates to alias :extra-deps when upgrading."}})
+                        :desc "Prevents updates to alias :extra-deps when upgrading."}
+           :sha {:desc "When provided, assumes lib refers to Github repo."
+                 :coerce :string}
+           :tag {:desc "When provided, assumes lib refers to Github repo."
+                 :coerce :string}
+           :version {:desc "Optional. When not provided, picks newest version from Clojars or Maven Central."
+                     :coerce :string}})
 
 (def windows? (fs/windows?))
 

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -759,6 +759,7 @@ Examples:
         alias         (some-> opts :alias)
         deps-to-check (opts->specified-deps opts)
         upgrades      (->> deps-to-check
+                           (remove :neil/pinned)
                            (pmap (fn [dep] (merge dep {:latest (dep->upgrade dep)})))
                            ;; keep if :latest version was found
                            (filter (fn [dep] (some? (:latest dep)))))]

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -474,6 +474,9 @@ chmod +x bin/kaocha
                     (-> nodes
                         (r/assoc-in (conj path :deps/root) root))
                     nodes)
+            nodes (if (:pin opts)
+                    (r/assoc-in nodes (conj path :neil/pinned) true)
+                    nodes)
             s (str (str/trim (str nodes)) "\n")]
         (when-not missing?
           (spit (:deps-file opts) s))))))
@@ -932,7 +935,8 @@ test
      :fn (fn [{:keys [opts] :as m}]
            (if (:version opts)
              (neil-version/print-version)
-             (print-help m)))}]
+             (print-help m)))}
+    {:cmds ["debug"] :fn prn}]
    *command-line-args*
    {:spec spec
     :exec-args {:deps-file "deps.edn"}})

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -34,7 +34,6 @@
            :limit {:coerce :long :desc "When provided, overrides number of versions from Maven/Clojars"}
            :no-aliases {:coerce :boolean
                         :desc "Prevents updates to alias :extra-deps when upgrading."}
-           :pin {:coerce :boolean :desc "When set, pins the version of the selected dependency."}
            :sha {:desc "When provided, assumes lib refers to Github repo."
                  :coerce :string}
            :tag {:desc "When provided, assumes lib refers to Github repo."
@@ -372,7 +371,7 @@ chmod +x bin/kaocha
   (println "Options:")
   (println (cli/format-opts
             {:spec spec
-             :order [:lib :version :sha :latest-sha :tag :latest-tag :deps/root :as :alias :deps-file :pin]})))
+             :order [:lib :version :sha :latest-sha :tag :latest-tag :deps/root :as :alias :deps-file]})))
 
 (defn log [& xs]
   (binding [*out* *err*]
@@ -473,9 +472,6 @@ chmod +x bin/kaocha
             nodes (if-let [root (and (or git-sha? git-tag?) (:deps/root opts))]
                     (-> nodes
                         (r/assoc-in (conj path :deps/root) root))
-                    nodes)
-            nodes (if (not= ::undefined (:pin opts ::undefined))
-                    (r/assoc-in nodes (conj path :neil/pinned) (:pin opts))
                     nodes)
             s (str (str/trim (str nodes)) "\n")]
         (when-not missing?

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -750,7 +750,6 @@ Examples:
   neil dep upgrade :lib clj-kondo/clj-kondo  ; update a single dep.
 "))
     (System/exit 0))
-
   (let [lib           (some-> opts :lib symbol)
         alias         (some-> opts :alias)
         deps-to-check (->> (opts->specified-deps opts)

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -34,6 +34,7 @@
            :limit {:coerce :long :desc "When provided, overrides number of versions from Maven/Clojars"}
            :no-aliases {:coerce :boolean
                         :desc "Prevents updates to alias :extra-deps when upgrading."}
+           :pin {:coerce :boolean :desc "When provided, pins the version of the selected dependency."}
            :sha {:desc "When provided, assumes lib refers to Github repo."
                  :coerce :string}
            :tag {:desc "When provided, assumes lib refers to Github repo."

--- a/test/babashka/neil/dep_upgrade_test.clj
+++ b/test/babashka/neil/dep_upgrade_test.clj
@@ -43,12 +43,9 @@
       (is (not (= clj-kondo-version-original (get-dep-version 'clj-kondo/clj-kondo))))))
 
   (testing "pinned dependencies arent updated"
-    (spit test-file-path "{}")
-    (test-util/neil "dep add :lib clj-kondo/clj-kondo" :deps-file test-file-path)
-    )
-
-
-  )
+    (spit test-file-path "{:deps {hiccup/hiccup {:mvn/version \"1.0.0\" :neil/pinned true}}}")
+    (test-util/neil "dep upgrade" :deps-file test-file-path)
+    (is (= "1.0.0" (:mvn/version (get-dep-version 'hiccup/hiccup))))))
 
 (deftest dep-upgrade-test-one-lib
   (testing "specifying :lib only updates one dep"

--- a/test/babashka/neil/dep_upgrade_test.clj
+++ b/test/babashka/neil/dep_upgrade_test.clj
@@ -40,7 +40,15 @@
 
       ;; after a non-dry-run, the version should be changed
       (test-util/neil "dep upgrade" :deps-file test-file-path)
-      (is (not (= clj-kondo-version-original (get-dep-version 'clj-kondo/clj-kondo)))))))
+      (is (not (= clj-kondo-version-original (get-dep-version 'clj-kondo/clj-kondo))))))
+
+  (testing "pinned dependencies arent updated"
+    (spit test-file-path "{}")
+    (test-util/neil "dep add :lib clj-kondo/clj-kondo" :deps-file test-file-path)
+    )
+
+
+  )
 
 (deftest dep-upgrade-test-one-lib
   (testing "specifying :lib only updates one dep"

--- a/test/babashka/neil/dep_upgrade_test.clj
+++ b/test/babashka/neil/dep_upgrade_test.clj
@@ -43,14 +43,11 @@
       (test-util/neil "dep upgrade" :deps-file test-file-path)
       (is (not (= clj-kondo-version-original (get-dep-version 'clj-kondo/clj-kondo))))))
 
-  (testing "pinned dependencies aren't updated"
+  (testing "dependencies can be pinned to avoid updates"
     (spit test-file-path "{:deps {hiccup/hiccup {:mvn/version \"1.0.0\" :neil/pinned true} cheshire/cheshire {:mvn/version \"4.0.0\"}}}")
     (test-util/neil "dep upgrade" :deps-file test-file-path)
     (is (= "1.0.0" (:mvn/version (get-dep-version 'hiccup/hiccup))) "Pinned deps are left alone")
-    (let [updated-cheshire-version (:mvn/version (get-dep-version 'cheshire/cheshire))]
-      (is (not (nil? updated-cheshire-version)))
-      (is (not= "4.0.0" updated-cheshire-version))
-      (is (version-clj/older? "4.0.0" updated-cheshire-version)))))
+    (is (version-clj/older? "4.0.0" (:mvn/version (get-dep-version 'cheshire/cheshire))) "Unpinned, outdated deps are updated")))
 
 (deftest dep-upgrade-test-one-lib
   (testing "specifying :lib only updates one dep"

--- a/test/babashka/neil/dep_upgrade_test.clj
+++ b/test/babashka/neil/dep_upgrade_test.clj
@@ -42,7 +42,7 @@
       (test-util/neil "dep upgrade" :deps-file test-file-path)
       (is (not (= clj-kondo-version-original (get-dep-version 'clj-kondo/clj-kondo))))))
 
-  (testing "pinned dependencies arent updated"
+  (testing "pinned dependencies aren't updated"
     (spit test-file-path "{:deps {hiccup/hiccup {:mvn/version \"1.0.0\" :neil/pinned true}}}")
     (test-util/neil "dep upgrade" :deps-file test-file-path)
     (is (= "1.0.0" (:mvn/version (get-dep-version 'hiccup/hiccup))))))


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
    - https://github.com/babashka/neil/issues/227

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/neil/blob/main/CHANGELOG.md) file with a description of the addressed issue.

- [x] I have considered whether I should add more tests covering the code I've changed.
    - One test added.

## Progress

I'm ready to merge if everything looks good.

## Motivation

`neil` users may not always want to update a dependency, for example due to introduced breaking changes. Currently, `neil dep upgrade` will upgrade all those dependencies, and the user will have to revert the change by hand.

## Implemented behavior

Dependencies in `deps.edn` can now  be pinned. Pinned dependencies have `:neil/pinned` set to `true`. Running `neil dep upgrade` on the following `deps.edn` file will upgrade `cheshire/cheshire`, but leave `hiccup/hiccup` alone.

```clojure
{:deps {hiccup/hiccup {:mvn/version "1.0.0"
                       :neil/pinned true}
        cheshire/cheshire {:mvn/version "4.0.0"}}
 :aliases {}}
```

Pinned dependencies are ignored when `neil dep upgrade` updates dependencies.

## Future ideas

`neil dep add` could support an optional `--pin` argument. Something like this:

    neil dep add hiccup --pin

