### PR TITLE
Add test: pinned git deps are not changed

### DIFF
--- a/test/babashka/neil/dep_upgrade_test.clj
+++ b/test/babashka/neil/dep_upgrade_test.clj
@@ -47,7 +47,16 @@
     (spit test-file-path "{:deps {hiccup/hiccup {:mvn/version \"1.0.0\" :neil/pinned true} cheshire/cheshire {:mvn/version \"4.0.0\"}}}")
     (test-util/neil "dep upgrade" :deps-file test-file-path)
     (is (= "1.0.0" (:mvn/version (get-dep-version 'hiccup/hiccup))) "Pinned deps are left alone")
-    (is (version-clj/older? "4.0.0" (:mvn/version (get-dep-version 'cheshire/cheshire))) "Unpinned, outdated deps are updated")))
+    (is (version-clj/older? "4.0.0" (:mvn/version (get-dep-version 'cheshire/cheshire))) "Unpinned, outdated deps are updated"))
+
+  (testing "pinned git deps are left unchanged"
+    (let [deps '{:deps {io.github.nextjournal/markdown
+                        {:git/sha "6683c48dfdb23404a23057817b6ac3acf0310bca"
+                         :neil/pinned true}}}]
+      (spit test-file-path deps)
+      (test-util/neil "dep upgrade" :deps-file test-file-path)
+      (is (= deps
+             (edn/read-string (slurp test-file-path)))))))
 
 (deftest dep-upgrade-test-one-lib
   (testing "specifying :lib only updates one dep"


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
    - I believe https://github.com/babashka/neil/issues/230 is actually not a bug, but we might as well cover the case in question against future regressions.

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/neil/blob/main/CHANGELOG.md) file with a description of the addressed issue.
    - I don't believe a CHANGELOG entry is warranted.

- [x] I have considered whether I should add more tests covering the code I've changed.
    - This PR contains a test.

---

I'm unable to reproduce https://github.com/babashka/neil/issues/230 locally.

- This test is green on my computer
- `neil-dev dep upgrade` works as I expect (run from latest master)
- `neil dep upgrade` works as I expect (`neil 0.3.67`)

But I don't think a test covering the case would hurt.