### PR TITLE
More specific message when github auth fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ See the [New Clojure project quickstart](https://blog.michielborkent.nl/new-cloj
 ## Unreleased
 
 - [#230](https://github.com/babashka/neil/issues/230): neil dep upgrade inserts git/url into upgraded dep ([@teodorlu](https://github.com/teodorlu))
+- [#237](https://github.com/babashka/neil/issues/230): more specific error reporting on invalid github token ([@teodorlu](https://github.com/teodorlu))
 
 ## 0.3.66
 

--- a/test/babashka/neil/dep_add_test.clj
+++ b/test/babashka/neil/dep_add_test.clj
@@ -6,4 +6,4 @@
 (deftest latest-version-test
   (is (= "1.0.5" (neil/latest-stable-clojars-version 'hiccup/hiccup)))
   (is (= "2.0.0-RC3" (neil/latest-clojars-version 'hiccup/hiccup)))
-  (is (= "1.11.3" (neil/latest-stable-mvn-version 'org.clojure/clojure))))
+  (is (= "1.11.4" (neil/latest-stable-mvn-version 'org.clojure/clojure))))


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
    - #237 

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/neil/blob/main/CHANGELOG.md) file with a description of the addressed issue.

- [x] I have considered whether I should add more tests covering the code I've changed.
    - We don't currently write test that assert the contents of error messages on stdin, and I don't see a good reason to change that practice now.

## Proposed solution

**Invalid Github token error messages before this PR:**

```
$ neil dep upgrade
{"message":"Bad credentials","documentation_url":"https://docs.github.com/rest","status":"401"}
{"message":"Bad credentials","documentation_url":"https://docs.github.com/rest","status":"401"}
```

**Invalid Github token error messages after this PR:**

```
$ neil-dev dep upgrade
Your neil github token is invalid or expired.
Please double check your  NEIL_GITHUB_TOKEN  environment variable.
See neil's README for more details.
Your neil github token is invalid or expired.
Please double check your  NEIL_GITHUB_TOKEN  environment variable.
See neil's README for more details.
```

## Other changes

- Behavior outside of error messages is left unchanged
- I pulled the environment variables for Github tokens (eg `NEIL_GITHUB_TOKEN`) into a `def` in order to provide more specific error messages

## Error message formatting

Other error messages are printed with the first line not indented, and following lines indented:

```
You've hit the github rate-limit (60 reqs/hr).
  You can set an API Token to increase the limit.
  See neil's README for details.
```

I'm not sure whether this is the desired way to print errors, or if it's accidental, eg code indenting. Clarification welcome!