### PR TITLE
Fix README instructions for dev installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ See the [New Clojure project quickstart](https://blog.michielborkent.nl/new-cloj
 - [#258](https://github.com/babashka/neil/issues/258): `neil test` now exits with non-zero exit code when tests fail
 - neil.el - a hook that runs after finding a package ([@agzam](https://github.com/agzam))
 - neil.el - adds a function for injecting a found package into current CIDER session ([@agzam](https://github.com/agzam))
+- README - fix development install instructions ([@teodorlu](https://github.com/teodorlu))
 
 ## 0.3.69
 

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ $ brew reinstall --build-from-source ./neil.rb
 Or install a development version with [bbin][bbin]:
 
 ```
-$ bbin install . --as neil-dev --main-opts '["-m" babashka.neil/-main]'
+$ bbin install . --as neil-dev --main-opts '["-m" "babashka.neil/-main"]'
 ```
 
 You can choose your own binary name with the `--as YOUR_BINARY` option.

--- a/README.template.md
+++ b/README.template.md
@@ -246,7 +246,7 @@ $ brew reinstall --build-from-source ./neil.rb
 Or install a development version with [bbin][bbin]:
 
 ```
-$ bbin install . --as neil-dev --main-opts '["-m" babashka.neil/-main]'
+$ bbin install . --as neil-dev --main-opts '["-m" "babashka.neil/-main"]'
 ```
 
 You can choose your own binary name with the `--as YOUR_BINARY` option.


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/neil/blob/main/CHANGELOG.md) file with a description of the addressed issue.

- [x] I have considered whether I should add more tests covering the code I've changed.

### Summary

As of `bbin 0.2.5`, README instructions for installing `neil-dev` for local development did not work. After this PR, installing `neil-dev` from README instructions works.

### References

The README dev install problem was discussed on Clojurians Slack: https://clojurians.slack.com/archives/C02FBBU61A9/p1774347319511029?thread_ts=1774345892.626849&cid=C02FBBU61A9

The `bbin` README had the same problem (https://github.com/babashka/bbin/issues/106), which was fixed (https://github.com/babashka/bbin/commit/078238f2198db7cb59caec6c26832b1950b81b8f).