### PR TITLE
Fix #261: upgrade unstable deps to newer unstable version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ See the [New Clojure project quickstart](https://blog.michielborkent.nl/new-cloj
 ## ...
 
 - [#261](https://github.com/babashka/neil/issues/261): `neil dep upgrade` now upgrades unstable deps (e.g. release candidates) to a newer unstable version when no newer stable version exists
+- `neil dep search` for a fully-qualified lib (e.g. `org.clojure/clojurescript`) no longer fails: a `/` in the Solr query made central.sonatype.com return a 500
 - [#258](https://github.com/babashka/neil/issues/258): `neil test` now exits with non-zero exit code when tests fail
 - neil.el - a hook that runs after finding a package ([@agzam](https://github.com/agzam))
 - neil.el - adds a function for injecting a found package into current CIDER session ([@agzam](https://github.com/agzam))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ See the [New Clojure project quickstart](https://blog.michielborkent.nl/new-cloj
 
 ## ...
 
+- [#261](https://github.com/babashka/neil/issues/261): `neil dep upgrade` now upgrades unstable deps (e.g. release candidates) to a newer unstable version when no newer stable version exists
 - [#258](https://github.com/babashka/neil/issues/258): `neil test` now exits with non-zero exit code when tests fail
 - neil.el - a hook that runs after finding a package ([@agzam](https://github.com/agzam))
 - neil.el - adds a function for injecting a found package into current CIDER session ([@agzam](https://github.com/agzam))

--- a/neil
+++ b/neil
@@ -1417,9 +1417,17 @@ See http://github.com/clojars/clojars-web/wiki/Search-Query-Syntax for
 details on the search syntax.")))
 
 (defn dep-search-maven [search-term]
-  (let [url (format
+  (let [;; A fully-qualified lib (group/artifact) can't be passed to Solr
+        ;; verbatim: the `/` is a special character (starts a regex) and makes
+        ;; central.sonatype.com return a 500. Search by the `a:` field instead
+        ;; (which aggregates to latest versions) and filter to the group below.
+        search-term (str/replace search-term #"^\"|\"$" "") ; strip surrounding quotes
+        [group artifact] (when (str/includes? search-term "/")
+                           (str/split search-term #"/" 2))
+        query (if group (str "a:" artifact) search-term)
+        url (format
              "https://central.sonatype.com/solrsearch/select?q=%s&rows=20&wt=json"
-             (url-encode search-term))
+             (url-encode query))
         keys-m {:g :group_name
                 :a :jar_name
                 :timestamp :created
@@ -1431,11 +1439,12 @@ details on the search syntax.")))
                     m :description
                     (format "%s/%s on Maven" group_name jar_name)))
         res (->> url curl-get-json :response :docs
-                    (map #(some->
-                           %
-                           (clojure.set/rename-keys keys-m)
-                           (select-keys (vals keys-m))
-                           add-desc)))]
+                 (filter (fn [{:keys [g]}] (or (nil? group) (= group g))))
+                 (map #(some->
+                        %
+                        (clojure.set/rename-keys keys-m)
+                        (select-keys (vals keys-m))
+                        add-desc)))]
     (if (empty? res)
       (binding [*out* *err*]
         (println "Unable to find" search-term "on Maven."))

--- a/neil
+++ b/neil
@@ -1548,7 +1548,7 @@ details on the search syntax.")))
          ;; otherwise, provide a more recent unstable
          (when-let [candidate (or (first clojars-candidates) (first maven-candidates))]
            (when (v-older? (:mvn/version current) candidate)
-             candidate))
+             {:mvn/version candidate}))
 
          ;; otherwise, do nothing (fall through to nil)
          )))))

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -541,9 +541,17 @@ See http://github.com/clojars/clojars-web/wiki/Search-Query-Syntax for
 details on the search syntax.")))
 
 (defn dep-search-maven [search-term]
-  (let [url (format
+  (let [;; A fully-qualified lib (group/artifact) can't be passed to Solr
+        ;; verbatim: the `/` is a special character (starts a regex) and makes
+        ;; central.sonatype.com return a 500. Search by the `a:` field instead
+        ;; (which aggregates to latest versions) and filter to the group below.
+        search-term (str/replace search-term #"^\"|\"$" "") ; strip surrounding quotes
+        [group artifact] (when (str/includes? search-term "/")
+                           (str/split search-term #"/" 2))
+        query (if group (str "a:" artifact) search-term)
+        url (format
              "https://central.sonatype.com/solrsearch/select?q=%s&rows=20&wt=json"
-             (url-encode search-term))
+             (url-encode query))
         keys-m {:g :group_name
                 :a :jar_name
                 :timestamp :created
@@ -555,11 +563,12 @@ details on the search syntax.")))
                     m :description
                     (format "%s/%s on Maven" group_name jar_name)))
         res (->> url curl-get-json :response :docs
-                    (map #(some->
-                           %
-                           (clojure.set/rename-keys keys-m)
-                           (select-keys (vals keys-m))
-                           add-desc)))]
+                 (filter (fn [{:keys [g]}] (or (nil? group) (= group g))))
+                 (map #(some->
+                        %
+                        (clojure.set/rename-keys keys-m)
+                        (select-keys (vals keys-m))
+                        add-desc)))]
     (if (empty? res)
       (binding [*out* *err*]
         (println "Unable to find" search-term "on Maven."))

--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -672,7 +672,7 @@ details on the search syntax.")))
          ;; otherwise, provide a more recent unstable
          (when-let [candidate (or (first clojars-candidates) (first maven-candidates))]
            (when (v-older? (:mvn/version current) candidate)
-             candidate))
+             {:mvn/version candidate}))
 
          ;; otherwise, do nothing (fall through to nil)
          )))))

--- a/test/babashka/neil/dep_add_test.clj
+++ b/test/babashka/neil/dep_add_test.clj
@@ -6,4 +6,4 @@
 (deftest latest-version-test
   (is (= "2.0.0" (neil/latest-stable-clojars-version 'hiccup/hiccup)))
   (is (= "2.0.0" (neil/latest-clojars-version 'hiccup/hiccup)))
-  (is (= "1.12.4" (neil/latest-stable-mvn-version 'org.clojure/clojure))))
+  (is (= "1.12.5" (neil/latest-stable-mvn-version 'org.clojure/clojure))))

--- a/test/babashka/neil/dep_upgrade_test.clj
+++ b/test/babashka/neil/dep_upgrade_test.clj
@@ -224,6 +224,15 @@
   (is (some? (neil/dep->upgrade {:lib 'com.google.apis/google-api-services-sheets
                                  :current {:mvn/version "v4-rev20220927-2.0.0"}}))))
 
+(deftest upgrade-unstable-to-unstable-test
+  ;; https://github.com/babashka/neil/issues/261
+  ;; When no newer stable version exists, upgrade to a newer unstable version.
+  ;; The result must be a {:mvn/version ...} map, not a bare version string.
+  (let [upgrade (neil/dep->upgrade {:lib 'dev.data-star.clojure/sdk
+                                    :current {:mvn/version "1.0.0-RC8"}})]
+    (is (map? upgrade) "an upgrade map is returned, not a bare string")
+    (is (string? (:mvn/version upgrade)) "the upgrade has a :mvn/version")))
+
 (deftest first-stable-version-test
   (are [all-versions first-stable] (= first-stable (neil/first-stable-version all-versions))
     ["1.0.4"] "1.0.4"


### PR DESCRIPTION
dep->upgrade returned a bare version string in the unstable-to-unstable fallback branch, but do-dep-upgrade destructures :latest as a map. The string destructured to all-nil, so no upgrade was written and no error shown. Return {:mvn/version candidate} like the other branches.

